### PR TITLE
Add prefab details pages and link from listing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,16 @@ collections:
   prefabs:
     permalink: "/prefabs/:name/"
     output: true
+  prefab_docs:
+    output: true
+    permalink: "/prefabs/details/:name/"
+
+defaults:
+  - scope:
+      type: prefab_docs
+    values:
+      layout: default
+      nav_exclude: true
 
 plugins:
 - jekyll-github-metadata

--- a/_layouts/prefab.html
+++ b/_layouts/prefab.html
@@ -21,9 +21,8 @@ search_exclude: false
   <tbody>
     {% for row in prefab_data %}
       <tr>
-        {% for cell in row %}
-          <td>{{ cell }}</td>
-        {% endfor %}
+        <td><a href="{{ '/prefabs/details/' | append: row[0] | relative_url }}">{{ row[0] }}</a></td>
+        <td>{{ row[1] }}</td>
       </tr>
     {% endfor %}
   </tbody>

--- a/_prefab_docs
+++ b/_prefab_docs
@@ -1,0 +1,1 @@
+_data/prefabs


### PR DESCRIPTION
## Summary
- expose prefab dump Markdown files as a new `prefab_docs` collection
- default prefab docs pages to the standard layout and hide from navigation
- link prefab names in listing tables to their corresponding dump page

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: Interrupt during build due to large number of pages)*

------
https://chatgpt.com/codex/tasks/task_e_68714cf447cc832d81554a839d326863