### PR TITLE
Link prefab docs locally

### DIFF
--- a/_layouts/prefab.html
+++ b/_layouts/prefab.html
@@ -25,7 +25,7 @@ search_exclude: false
         {% assign link_category = site.data.prefab_category_map[row[0]] %}
       {% endif %}
       <tr>
-        <td><a href="https://github.com/decaprime/vrising-modding/blob/main/_data/prefabs/{{ link_category }}/{{ row[0] }}.md">{{ row[0] }}</a></td>
+        <td><a href="{{ '/_prefab_docs/' | append: link_category | append: '/' | append: row[0] | append: '.md' | relative_url }}">{{ row[0] }}</a></td>
         <td>{{ row[1] }}</td>
       </tr>
     {% endfor %}

--- a/_prefab_docs
+++ b/_prefab_docs
@@ -1,0 +1,1 @@
+_data/prefabs


### PR DESCRIPTION
## Summary
- add `_prefab_docs` symlink pointing to existing prefab data
- update `prefab.html` links to use the local prefab docs collection

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: Interrupt during build with Liquid Exception)*

------
https://chatgpt.com/codex/tasks/task_e_6871c0090e84832dbb2a2d2c7880417f