### PR TITLE
Enable Lunr search and add callout/DataTable shortcodes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,9 +21,8 @@ params:
   back_to_top_text: "Back to top"
   color_scheme: vampire
   search:
-    enabled: true
-    heading_level: 4
-    tokenizer: "[\\s/_-]+"
+    adapter:
+      identifier: lunr
   focus_shortcut_key: "k"
   aux_links:
     "V Rising Thunderstore": "https://thunderstore.io/c/v-rising/"

--- a/content/prefabs/VBloodNames.md
+++ b/content/prefabs/VBloodNames.md
@@ -6,5 +6,4 @@ nav_exclude: false
 search_exclude: false
 ---
 
-{{< data_table_search >}}
 {{< vblood_names_table >}}

--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -1,0 +1,7 @@
+{{- $_hugo_config := `{ "version": 1 }` -}}
+{{- partial "shortcodes/notice.html" (dict
+  "page" .Page
+  "style" "note"
+  "title" "Note"
+  "content" .Inner
+) -}}

--- a/layouts/shortcodes/vblood_names_table.html
+++ b/layouts/shortcodes/vblood_names_table.html
@@ -1,4 +1,5 @@
 {{ $data := index site.Data.prefabs .Page.Params.data_file }}
+{{ partial "data_table_search.html" . }}
 <table>
   <thead>
     <tr>

--- a/layouts/shortcodes/warning.html
+++ b/layouts/shortcodes/warning.html
@@ -1,0 +1,7 @@
+{{- $_hugo_config := `{ "version": 1 }` -}}
+{{- partial "shortcodes/notice.html" (dict
+  "page" .Page
+  "style" "warning"
+  "title" "Warning"
+  "content" .Inner
+) -}}


### PR DESCRIPTION
## Summary
- configure Relearn theme search to use Lunr
- add warning and note callout shortcodes
- integrate DataTables assets into prefab tables

## Testing
- `/usr/local/bin/hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_689a9fade974832da1d9c1c3ff8df1c4