### PR TITLE
Use relative links for internal wiki pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This repository contains the source for the V Rising Modding Wiki. It is built with [Hugo](https://gohugo.io/) using the Relearn theme. Markdown content lives in the `content/` directory.
 
-## Visit the wiki: https://wiki.vrisingmods.com
+## Visit the wiki: [Home](/)
 
 ## Local development
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -20,7 +20,7 @@ New to **V Rising mod development**? Follow these steps to begin:
 
 -  Learn how to [build a V Rising mod](/dev/#how-to-make-a-vrising-mod).  
 -  Find the [recommended set up for development](/dev/development_setup.md). 
--  Review our array of various [open source mods](https://wiki.vrisingmods.com/dev/open%20source.html) to learn from example!  
+-  Review our array of various [open source mods](/dev/open%20source/) to learn from example!
 
 
 ## Contribute to the Wiki
@@ -31,6 +31,6 @@ This wiki is a community-driven project, and we encourage you to contribute!
 - Share your modding knowledge  
 - Fix outdated information  
 
-If you have knowledge to share, feel free to [edit pages or submit new content](https://wiki.vrisingmods.com/editing.html) via GitHub.
+If you have knowledge to share, feel free to [edit pages or submit new content](/editing/) via GitHub.
 
 {:toc}

--- a/content/dev/development_setup.md
+++ b/content/dev/development_setup.md
@@ -57,5 +57,5 @@ For more advanced users or if you want full control over Git, you can install Gi
 ---
 
 ## Template
-A Command Prompt or PowerShell window should be opened in the folder where you want your mods to be created. Follow template install instructions from the [Template Page](https://wiki.vrisingmods.com/dev/template.html).
+A Command Prompt or PowerShell window should be opened in the folder where you want your mods to be created. Follow template install instructions from the [Template Page]({{< relref "dev/template.md" >}}).
 

--- a/content/dev/resources.md
+++ b/content/dev/resources.md
@@ -6,11 +6,11 @@ title: Resources
 
 ## Wiki Resources
 
-- [**Open Source Repositories**](https://wiki.vrisingmods.com/dev/open%20source.html)
+- [**Open Source Repositories**](/dev/open%20source/)
   - The VRising modding community focuses on open-source mods to encourage learning and the development of new features. Feel free to explore and reference any of the open-source mods listed here, but please be sure to **credit the creators** and follow any relevant license requirements.
-- [**Prefabs list**](https://wiki.vrisingmods.com/prefabs/)
+- [**Prefabs list**]({{< relref "prefabs" >}})
   - Lists of the various prefabs, grouped by type, or you can review all of them.
-- [**GPT Instructions**](https://wiki.vrisingmods.com/dev/gpt_instructions.html)
+- [**GPT Instructions**]({{< relref "dev/gpt_instructions.md" >}})
   - Instructions to help guide responses for [C#(Rising)](https://chatgpt.com/g/g-XGdFZaBHL-c-rising).
   
 ---

--- a/content/user/Mod_Install.md
+++ b/content/user/Mod_Install.md
@@ -5,7 +5,7 @@ weight: 2
 
 # Manually installing Mods
 
-If you're manually installing mods, you need to install BepInEx first. Reference [this page](https://wiki.vrisingmods.com/user/bepinex_install.html) if you have not completed this step.
+If you're manually installing mods, you need to install BepInEx first. Reference [this page]({{< relref "user/bepinex_install.md" >}}) if you have not completed this step.
 Do remember that BepInEx will take some time to generate all of the files, so give it time on first boot up and after any game hotfixes.
 
 ### Dependencies

--- a/content/user/_index.md
+++ b/content/user/_index.md
@@ -10,8 +10,8 @@ has_toc: false
 - Support: Check out support channels in the discord or in the mod's readme
 
 ## Installation
-- [Manual BepInEx Installation](https://wiki.vrisingmods.com/user/bepinex_install.html)
-- [Manual Mod Installation](https://wiki.vrisingmods.com/user/Mod_Install.html)
-- [Using Server Mods in-game](https://wiki.vrisingmods.com/user/Using_Server_Mods.html)
+- [Manual BepInEx Installation]({{< relref "user/bepinex_install.md" >}})
+- [Manual Mod Installation]({{< relref "user/Mod_Install.md" >}})
+- [Using Server Mods in-game]({{< relref "user/Using_Server_Mods.md" >}})
 
-### If you wish to play an earlier version of V Rising: [Client Rollback](https://wiki.vrisingmods.com/user/client_rollback.html) 
+### If you wish to play an earlier version of V Rising: [Client Rollback]({{< relref "user/client_rollback.md" >}})


### PR DESCRIPTION
## Summary
- Replace hard-coded `https://wiki.vrisingmods.com` links with Hugo `relref` or relative paths in user guides and resources
- Update README to point to the wiki root with a relative link

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_689ad045e43c832db00fc0a5f095db78