### PR TITLE
docs: fix template command typo

### DIFF
--- a/content/dev/_index.md
+++ b/content/dev/_index.md
@@ -8,7 +8,7 @@ title: For Developers
 Set up your [development environment](./development_setup.md).
 
 ### Template
-We have a mod [template](./template.md) to make getting started simple as [`dotnet new vrisngmod`](./template.md).
+We have a mod [template](./template.md) to make getting started simple as [`dotnet new vrisingmod`](./template.md).
 
 ### Resources
 You can reference [resources](./resources.md) and [open source](./open%20source.md) for more information for now.


### PR DESCRIPTION
## Summary
- fix template command typo to `dotnet new vrisingmod`

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_689ad2c60924832dbffff86b404e5d5b