### PR TITLE
chore: remove nav and search exclusions from prefabs

### DIFF
--- a/content/prefabs/AB.md
+++ b/content/prefabs/AB.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: AB
 data_file: AB
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/AI.md
+++ b/content/prefabs/AI.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: AI
 data_file: AI
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Ability.md
+++ b/content/prefabs/Ability.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Ability
 data_file: Ability
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Aim.md
+++ b/content/prefabs/Aim.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Aim
 data_file: Aim
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/All.md
+++ b/content/prefabs/All.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: All
 data_file: All
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Ascendancy.md
+++ b/content/prefabs/Ascendancy.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Ascendancy
 data_file: Ascendancy
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/BEH.md
+++ b/content/prefabs/BEH.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: BEH
 data_file: BEH
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/BP.md
+++ b/content/prefabs/BP.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: BP
 data_file: BP
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Base.md
+++ b/content/prefabs/Base.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Base
 data_file: Base
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Biome.md
+++ b/content/prefabs/Biome.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Biome
 data_file: Biome
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Blood.md
+++ b/content/prefabs/Blood.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Blood
 data_file: Blood
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Braziers.md
+++ b/content/prefabs/Braziers.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Braziers
 data_file: Braziers
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Buff.md
+++ b/content/prefabs/Buff.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Buff
 data_file: Buff
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/CHAR.md
+++ b/content/prefabs/CHAR.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: CHAR
 data_file: CHAR
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/CO.md
+++ b/content/prefabs/CO.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: CO
 data_file: CO
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Castle.md
+++ b/content/prefabs/Castle.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Castle
 data_file: Castle
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Chain.md
+++ b/content/prefabs/Chain.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Chain
 data_file: Chain
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Copper.md
+++ b/content/prefabs/Copper.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Copper
 data_file: Copper
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Creature.md
+++ b/content/prefabs/Creature.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Creature
 data_file: Creature
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Critter.md
+++ b/content/prefabs/Critter.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Critter
 data_file: Critter
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Curtains.md
+++ b/content/prefabs/Curtains.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Curtains
 data_file: Curtains
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Curve.md
+++ b/content/prefabs/Curve.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Curve
 data_file: Curve
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/DG.md
+++ b/content/prefabs/DG.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: DG
 data_file: DG
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/DT.md
+++ b/content/prefabs/DT.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: DT
 data_file: DT
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Door.md
+++ b/content/prefabs/Door.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Door
 data_file: Door
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Dye.md
+++ b/content/prefabs/Dye.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Dye
 data_file: Dye
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Dynamic.md
+++ b/content/prefabs/Dynamic.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Dynamic
 data_file: Dynamic
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Dynamics.md
+++ b/content/prefabs/Dynamics.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Dynamics
 data_file: Dynamics
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/EH.md
+++ b/content/prefabs/EH.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: EH
 data_file: EH
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Ease.md
+++ b/content/prefabs/Ease.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Ease
 data_file: Ease
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Elris.md
+++ b/content/prefabs/Elris.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Elris
 data_file: Elris
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Equip.md
+++ b/content/prefabs/Equip.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Equip
 data_file: Equip
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Faction.md
+++ b/content/prefabs/Faction.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Faction
 data_file: Faction
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Fake.md
+++ b/content/prefabs/Fake.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Fake
 data_file: Fake
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Garden.md
+++ b/content/prefabs/Garden.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Garden
 data_file: Garden
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Gloom.md
+++ b/content/prefabs/Gloom.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Gloom
 data_file: Gloom
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Gravestone.md
+++ b/content/prefabs/Gravestone.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Gravestone
 data_file: Gravestone
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Graveyard.md
+++ b/content/prefabs/Graveyard.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Graveyard
 data_file: Graveyard
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Ground.md
+++ b/content/prefabs/Ground.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Ground
 data_file: Ground
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Illusion.md
+++ b/content/prefabs/Illusion.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Illusion
 data_file: Illusion
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Iron.md
+++ b/content/prefabs/Iron.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Iron
 data_file: Iron
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Item.md
+++ b/content/prefabs/Item.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Item
 data_file: Item
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Journal.md
+++ b/content/prefabs/Journal.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Journal
 data_file: Journal
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Map.md
+++ b/content/prefabs/Map.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Map
 data_file: Map
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Micro.md
+++ b/content/prefabs/Micro.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Micro
 data_file: Micro
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Milo.md
+++ b/content/prefabs/Milo.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Milo
 data_file: Milo
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Music.md
+++ b/content/prefabs/Music.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Music
 data_file: Music
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/NPCDeadeye.md
+++ b/content/prefabs/NPCDeadeye.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: NPCDeadeye
 data_file: NPCDeadeye
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/PVP.md
+++ b/content/prefabs/PVP.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: PVP
 data_file: PVP
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Quarry.md
+++ b/content/prefabs/Quarry.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Quarry
 data_file: Quarry
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Random.md
+++ b/content/prefabs/Random.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Random
 data_file: Random
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Recipe.md
+++ b/content/prefabs/Recipe.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Recipe
 data_file: Recipe
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Remainders.md
+++ b/content/prefabs/Remainders.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Remainders
 data_file: Remainders
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Resource.md
+++ b/content/prefabs/Resource.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Resource
 data_file: Resource
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Rock.md
+++ b/content/prefabs/Rock.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Rock
 data_file: Rock
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/SCT.md
+++ b/content/prefabs/SCT.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: SCT
 data_file: SCT
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Servant.md
+++ b/content/prefabs/Servant.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Servant
 data_file: Servant
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Set.md
+++ b/content/prefabs/Set.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Set
 data_file: Set
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Snapping.md
+++ b/content/prefabs/Snapping.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Snapping
 data_file: Snapping
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Snow.md
+++ b/content/prefabs/Snow.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Snow
 data_file: Snow
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Spell.md
+++ b/content/prefabs/Spell.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Spell
 data_file: Spell
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Stash.md
+++ b/content/prefabs/Stash.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Stash
 data_file: Stash
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Stat.md
+++ b/content/prefabs/Stat.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Stat
 data_file: Stat
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Station.md
+++ b/content/prefabs/Station.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Station
 data_file: Station
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Storm.md
+++ b/content/prefabs/Storm.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Storm
 data_file: Storm
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Sun.md
+++ b/content/prefabs/Sun.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Sun
 data_file: Sun
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/TM.md
+++ b/content/prefabs/TM.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: TM
 data_file: TM
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Tech.md
+++ b/content/prefabs/Tech.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Tech
 data_file: Tech
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Transmog.md
+++ b/content/prefabs/Transmog.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Transmog
 data_file: Transmog
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Trees.md
+++ b/content/prefabs/Trees.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Trees
 data_file: Trees
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/UC.md
+++ b/content/prefabs/UC.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: UC
 data_file: UC
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Undead.md
+++ b/content/prefabs/Undead.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Undead
 data_file: Undead
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Unholy.md
+++ b/content/prefabs/Unholy.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Unholy
 data_file: Unholy
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/VBloodNames.md
+++ b/content/prefabs/VBloodNames.md
@@ -2,8 +2,6 @@
 layout: default
 title: VBlood Names
 data_file: vblood_names
-nav_exclude: false
-search_exclude: false
 ---
 
 {{< vblood_names_table >}}

--- a/content/prefabs/VIB.md
+++ b/content/prefabs/VIB.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: VIB
 data_file: VIB
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/VM.md
+++ b/content/prefabs/VM.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: VM
 data_file: VM
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Vampire.md
+++ b/content/prefabs/Vampire.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Vampire
 data_file: Vampire
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Water.md
+++ b/content/prefabs/Water.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Water
 data_file: Water
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Weapon.md
+++ b/content/prefabs/Weapon.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Weapon
 data_file: Weapon
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/Wild.md
+++ b/content/prefabs/Wild.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: Wild
 data_file: Wild
-nav_exclude: true
-search_exclude: false
 ---

--- a/content/prefabs/ZM.md
+++ b/content/prefabs/ZM.md
@@ -2,6 +2,4 @@
 layout: prefab
 title: ZM
 data_file: ZM
-nav_exclude: true
-search_exclude: false
 ---


### PR DESCRIPTION
## Summary
- remove `nav_exclude` and `search_exclude` front matter from prefab pages
- ensure prefab markdown files end with a newline

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_689adf196438832da7b895d547f72f57