### PR TITLE
refactor: update front matter for Relearn

### DIFF
--- a/content/dev/_index.md
+++ b/content/dev/_index.md
@@ -1,5 +1,4 @@
 ---
-has_children: true
 title: For Developers
 ---
 # For Developers

--- a/content/dev/bloodstone.md
+++ b/content/dev/bloodstone.md
@@ -1,7 +1,7 @@
 ---
 title: Wetstone -> Bloodstone
-nav_exclude: true
-has_toc: false
+hidden: true
+disableToc: true
 ---
 
 ![bloodstone-banner](https://i.imgur.com/Py0MwUL.png)

--- a/content/dev/gloomrot.md
+++ b/content/dev/gloomrot.md
@@ -1,7 +1,7 @@
 ---
 title: Migration Guide for Gloomrot
-nav_exclude: true
-has_toc: false
+hidden: true
+disableToc: true
 ---
 
 # Migrating plugins for glooomrot

--- a/content/prefabs/_index.md
+++ b/content/prefabs/_index.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Prefabs
-has_children: true
 ---
 
 # Prefabs

--- a/content/user/_index.md
+++ b/content/user/_index.md
@@ -1,7 +1,6 @@
 ---
-has_children: true
 title: For Users
-has_toc: false
+disableToc: true
 ---
 
 # For users of mods

--- a/content/user/game_update.md
+++ b/content/user/game_update.md
@@ -1,8 +1,8 @@
 ---
 title: Oakveil Game Update
-nav_exclude: true
-has_toc: false
-hide: true
+hidden: true
+disableToc: true
+draft: true
 ---
 
 # Thunderstore releases: BepInEx and VCF have been updated to [thunderstore](https://thunderstore.io/c/v-rising/). This page is deprecated. 5/17

--- a/content/user/gloomrot_mods.md
+++ b/content/user/gloomrot_mods.md
@@ -1,6 +1,6 @@
 ---
 title: Gloomrot Mod Status
-nav_exclude: true
+hidden: true
 ---
 
 ## 🥳 We've released on Thunderstore


### PR DESCRIPTION
## Summary
- remove obsolete `nav_exclude`, `has_toc`, `has_children`, and `hide` front matter
- use Relearn equivalents `hidden`, `disableToc`, and `draft` where appropriate

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_689b6c064a20832d9a40e59c5e5f2e6f