### PR TITLE
Replace class markers with Relearn callouts

### DIFF
--- a/content/dev/resources.md
+++ b/content/dev/resources.md
@@ -35,10 +35,10 @@ Tools made by those in the community.
 ---
 
 ## Unity Explorer
-{: .d-inline-block }
 
+{{% notice info %}}
 [Unity Explorer](https://github.com/yukieiji/UnityExplorer) is a tool that allows you to dig into the internal structure of the game while it's running.
-
+{{% /notice %}}
 
 #### Prerequisites
 1. Install [BepInEx](https://thunderstore.io/c/v-rising/p/BepInEx/BepInExPack_V_Rising/) in VRising

--- a/content/user/game_update.md
+++ b/content/user/game_update.md
@@ -9,12 +9,9 @@ draft: true
 
 # RE: 1.1 - Updated 4/27
 Previous versions of mods and BepInEx do not work with the Oakveil game update. There will be an announcement in discord and versions published to Thunderstore when they are ready. We have a BepInEx release candidate that we need developers to update and test their mods with.
-
-{: .warning-title }
-> A Note
-> 
-> Please note Mods that are not yet updated may take some unknown amount of time to be updated to 1.1. We would like to remind all users who enjoy playing with mods to be patient and understand that modders are working on getting the mods updated and stable.
->
+{{% notice warning "A Note" %}}
+Please note Mods that are not yet updated may take some unknown amount of time to be updated to 1.1. We would like to remind all users who enjoy playing with mods to be patient and understand that modders are working on getting the mods updated and stable.
+{{% /notice %}}
 
 ### Intended for testing
 The remainder of this page is provided for developers and anyone willing to accept any risks in testing pre-released mods, don't expect tech support or full functionality. The purpose of this page is to help gather feedback, please report issues and bugs.


### PR DESCRIPTION
## Summary
- replace manual class markers with Relearn notice shortcodes
- remove obsolete warning and inline-block class lines

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_689b6f6ad2d4832dbff1aa151af9290e