### PR TITLE
Use extensionless internal links

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -19,8 +19,8 @@ Ready to **play** modded?
 New to **V Rising mod development**? Follow these steps to begin:  
 
 -  Learn how to [build a V Rising mod](/dev/#how-to-make-a-vrising-mod).  
--  Find the [recommended set up for development](/dev/development_setup.md). 
--  Review our array of various [open source mods](/dev/open%20source/) to learn from example!
+-  Find the [recommended set up for development](/dev/development_setup/).
+-  Review our array of various [open source mods](/dev/open-source/) to learn from example!
 
 ## Contribute to the Wiki
 

--- a/content/dev/_index.md
+++ b/content/dev/_index.md
@@ -4,13 +4,13 @@ title: For Developers
 # For Developers
 
 ## Getting started
-Set up your [development environment](./development_setup.md).
+Set up your [development environment](./development_setup/).
 
 ### Template
-We have a mod [template](./template.md) to make getting started simple as [`dotnet new vrisingmod`](./template.md).
+We have a mod [template](./template/) to make getting started simple as [`dotnet new vrisingmod`](./template/).
 
 ### Resources
-You can reference [resources](./resources.md) and [open source](./open-source.md) for more information for now.
+You can reference [resources](./resources/) and [open source](./open-source/) for more information for now.
 
 ### Thunderstore Uploading
-[Upload](./upload_to_thunderstore.md) your mods to thunderstore! Quick run down of how to navigate and set up your package.
+[Upload](./upload_to_thunderstore/) your mods to thunderstore! Quick run down of how to navigate and set up your package.

--- a/content/dev/resources.md
+++ b/content/dev/resources.md
@@ -6,11 +6,11 @@ title: Resources
 
 ## Wiki Resources
 
-- [**Open Source Repositories**](/dev/open%20source/)
+- [**Open Source Repositories**](/dev/open-source/)
   - The VRising modding community focuses on open-source mods to encourage learning and the development of new features. Feel free to explore and reference any of the open-source mods listed here, but please be sure to **credit the creators** and follow any relevant license requirements.
 - [**Prefabs list**]({{< relref "prefabs" >}})
   - Lists of the various prefabs, grouped by type, or you can review all of them.
-- [**GPT Instructions**]({{< relref "dev/gpt_instructions.md" >}})
+- [**GPT Instructions**]({{< relref "dev/gpt_instructions" >}})
   - Instructions to help guide responses for [C#(Rising)](https://chatgpt.com/g/g-XGdFZaBHL-c-rising).
   
 ---

--- a/content/dev/template.md
+++ b/content/dev/template.md
@@ -12,10 +12,10 @@ We have a mod template to make getting started easy. Adding dependencies will re
 ### Example usage
 `dotnet new vrisingmod -n NameOfYourMod --use-vcf --use-bloodstone --description "Description of your mod"`
 
-This will get you started with a mod named _NameOfYourMod_, using [Bloodstone](./bloodstone.md) and [VampireCommandFramework](https://github.com/decaprime/VampireCommandFramework/) that has a sample server command to uncomment.
+This will get you started with a mod named _NameOfYourMod_, using [Bloodstone]({{< relref "bloodstone" >}}) and [VampireCommandFramework](https://github.com/decaprime/VampireCommandFramework/) that has a sample server command to uncomment.
 ### Optional Dependencies (add using the --use tag)
 - [VampireCommandFramework](https://github.com/decaprime/VampireCommandFramework/)
-- [Bloodstone](./bloodstone.md)
+- [Bloodstone]({{< relref "bloodstone" >}})
 
 
 ---


### PR DESCRIPTION
## Summary
- use extensionless paths for internal links on developer pages
- refer to Bloodstone doc via Hugo relref shortcode
- update resource links to match new paths

## Testing
- `hugo` *(fails: template for shortcode "notice" not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b74abacdc832dbe9c1c997372f541