### PR TITLE
Add Relearn table-of-contents shortcode

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -32,4 +32,4 @@ This wiki is a community-driven project, and we encourage you to contribute!
 
 If you have knowledge to share, feel free to [edit pages or submit new content](/editing/) via GitHub.
 
-{:toc}
+{{< toc >}}

--- a/layouts/shortcodes/toc.html
+++ b/layouts/shortcodes/toc.html
@@ -1,0 +1,2 @@
+{{- partial "toc.html" .Page -}}
+


### PR DESCRIPTION
## Summary
- Replace Jekyll-style `{:toc}` with Relearn's `{{< toc >}}` shortcode on the home page
- Provide a `toc` shortcode that renders the theme's table of contents partial

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_689b7cb30308832d92e0662331d813d8