### PR TITLE
Remove .md extensions from internal documentation links

### DIFF
--- a/content/dev/development_setup.md
+++ b/content/dev/development_setup.md
@@ -57,5 +57,5 @@ For more advanced users or if you want full control over Git, you can install Gi
 ---
 
 ## Template
-A Command Prompt or PowerShell window should be opened in the folder where you want your mods to be created. Follow template install instructions from the [Template Page]({{< relref "dev/template.md" >}}).
+A Command Prompt or PowerShell window should be opened in the folder where you want your mods to be created. Follow template install instructions from the [Template Page]({{< relref "dev/template" >}}).
 

--- a/content/dev/gloomrot.md
+++ b/content/dev/gloomrot.md
@@ -14,7 +14,7 @@ This version of game libs privately packages the interop changes from above with
 Versioning on nuget is now game version+zero padded 4 digit version to clarify updates between game versions.
 
 
-### Plugins that used Wetstone: [Migration to Bloodstone](./bloodstone.md#migration-from-wetstone)
+### Plugins that used Wetstone: [Migration to Bloodstone](./bloodstone/#migration-from-wetstone)
 
 ## `.csproj` changes
 ```xml

--- a/content/user/Mod_Install.md
+++ b/content/user/Mod_Install.md
@@ -5,7 +5,7 @@ weight: 2
 
 # Manually installing Mods
 
-If you're manually installing mods, you need to install BepInEx first. Reference [this page]({{< relref "user/bepinex_install.md" >}}) if you have not completed this step.
+If you're manually installing mods, you need to install BepInEx first. Reference [this page]({{< relref "user/bepinex_install" >}}) if you have not completed this step.
 Do remember that BepInEx will take some time to generate all of the files, so give it time on first boot up and after any game hotfixes.
 
 ### Dependencies

--- a/content/user/_index.md
+++ b/content/user/_index.md
@@ -9,8 +9,8 @@ disableToc: true
 - Support: Check out support channels in the discord or in the mod's readme
 
 ## Installation
-- [Manual BepInEx Installation]({{< relref "user/bepinex_install.md" >}})
-- [Manual Mod Installation]({{< relref "user/Mod_Install.md" >}})
-- [Using Server Mods in-game]({{< relref "user/Using_Server_Mods.md" >}})
+- [Manual BepInEx Installation]({{< relref "user/bepinex_install" >}})
+- [Manual Mod Installation]({{< relref "user/Mod_Install" >}})
+- [Using Server Mods in-game]({{< relref "user/Using_Server_Mods" >}})
 
-### If you wish to play an earlier version of V Rising: [Client Rollback]({{< relref "user/client_rollback.md" >}})
+### If you wish to play an earlier version of V Rising: [Client Rollback]({{< relref "user/client_rollback" >}})


### PR DESCRIPTION
## Summary
- Use extensionless Hugo relref links for internal pages
- Update relative links to directory style paths

## Testing
- `hugo` *(fails: template for shortcode "notice" not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b9cad9dd0832db313f6ed75a82cdd