### PR TITLE
Activate custom vampire theme variant

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ sitemap:
 params:
   back_to_top: true
   back_to_top_text: "Back to top"
-  themeVariant: auto
+  themeVariant: vampire
   search:
     adapter:
       identifier: lunr


### PR DESCRIPTION
## Summary
- enable custom "vampire" theme variant by setting `themeVariant` to `vampire`

## Testing
- `hugo` *(fails: template for shortcode "notice" not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bc2c4cf60832d9479f03327ccfce8