### PR TITLE
Add notice shortcode

### DIFF
--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,0 +1,4 @@
+{{ $type := .Get 0 | default "info" }}
+<aside class="notice notice-{{$type}}">
+  {{ .Inner | markdownify }}
+</aside>


### PR DESCRIPTION
## Summary
- add `notice` shortcode that renders markdown content in a styled aside

## Testing
- `hugo server`
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_689c26eee7b4832db3d5589d2936c498