### PR TITLE
feat: add dev scripts for site build and preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,25 @@ git submodule update --init --recursive
 Generate the prefab file list and start the local preview server:
 
 ```bash
-python scripts/build_prefab_files.py
-hugo server
+./scripts/dev.sh serve
+```
+
+On Windows PowerShell:
+
+```powershell
+./scripts/dev.ps1 serve
 ```
 
 To generate the static site in the `public/` directory:
 
 ```bash
-python scripts/build_prefab_files.py
-hugo
+./scripts/dev.sh build
+```
+
+On Windows PowerShell:
+
+```powershell
+./scripts/dev.ps1 build
 ```
 
 See [editing.md](editing.md) for guidelines on contributing.

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -1,0 +1,16 @@
+param(
+    [Parameter(Position=0,Mandatory=$true)]
+    [ValidateSet('serve', 'build')]
+    [string]$Action
+)
+
+# Ensure submodules are initialized and updated
+git submodule update --init --recursive
+
+# Generate prefab file list
+python scripts/build_prefab_files.py
+
+switch ($Action) {
+    'serve' { hugo server }
+    'build' { hugo }
+}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [serve|build]" >&2
+  exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+fi
+
+action="$1"
+
+# Ensure submodules are initialized and updated
+git submodule update --init --recursive
+
+# Generate prefab file list
+python scripts/build_prefab_files.py
+
+case "$action" in
+  serve)
+    hugo server
+    ;;
+  build)
+    hugo
+    ;;
+  *)
+    usage
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add dev.sh script to update submodules, build prefabs, and run hugo
- add matching dev.ps1 for Windows users
- document new scripts in local development section

## Testing
- `./scripts/dev.sh build` *(fails: command not found: hugo)*
- `pwsh -NoLogo -Command "./scripts/dev.ps1 build"` *(fails: command not found: pwsh)*

------
https://chatgpt.com/codex/tasks/task_e_689c313f24d4832db3946992e5b235e4