### PR TITLE
fix permalink warning by using content basename

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ description: "Information about mods for the game V Rising: How to build, debug,
 theme: "hugo-theme-relearn"
 
 permalinks:
-  prefabs: "/prefabs/:filename/"
+  prefabs: "/prefabs/:contentbasename/"
 
 sitemap:
   changefreq: monthly


### PR DESCRIPTION
## Summary
- use `:contentbasename` for `prefabs` permalinks

## Testing
- `/usr/local/bin/hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_689cb71d3f98832d942c2d894ef34d08