### PR TITLE
Allow raw HTML rendering in Hugo config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,14 @@ title: "V Rising Mod Wiki"
 description: "Information about mods for the game V Rising: How to build, debug, and publish your mods."
 theme: "hugo-theme-relearn"
 
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
+
+ignoreLogs:
+  - warning-goldmark-raw-html
+
 permalinks:
   prefabs: "/prefabs/:contentbasename/"
 


### PR DESCRIPTION
## Summary
- enable Goldmark unsafe rendering to allow raw HTML
- silence Goldmark raw HTML warnings

## Testing
- `scripts/dev.sh build` *(fails: ERROR "theme-vampire.css": file not found in "assets/css")*

------
https://chatgpt.com/codex/tasks/task_e_689cc1183264832d89db146e20742080