### PR TITLE
Use raw shortcodes for internal references

### DIFF
--- a/content/dev/development_setup.md
+++ b/content/dev/development_setup.md
@@ -57,5 +57,5 @@ For more advanced users or if you want full control over Git, you can install Gi
 ---
 
 ## Template
-A Command Prompt or PowerShell window should be opened in the folder where you want your mods to be created. Follow template install instructions from the [Template Page]({{< relref "dev/template" >}}).
+A Command Prompt or PowerShell window should be opened in the folder where you want your mods to be created. Follow template install instructions from the [Template Page]({{% relref "dev/template" %}}).
 

--- a/content/dev/resources.md
+++ b/content/dev/resources.md
@@ -8,9 +8,9 @@ title: Resources
 
 - [**Open Source Repositories**](/dev/open-source/)
   - The VRising modding community focuses on open-source mods to encourage learning and the development of new features. Feel free to explore and reference any of the open-source mods listed here, but please be sure to **credit the creators** and follow any relevant license requirements.
-- [**Prefabs list**]({{< relref "prefabs" >}})
+- [**Prefabs list**]({{% relref "prefabs" %}})
   - Lists of the various prefabs, grouped by type, or you can review all of them.
-- [**GPT Instructions**]({{< relref "dev/gpt_instructions" >}})
+- [**GPT Instructions**]({{% relref "dev/gpt_instructions" %}})
   - Instructions to help guide responses for [C#(Rising)](https://chatgpt.com/g/g-XGdFZaBHL-c-rising).
   
 ---

--- a/content/dev/template.md
+++ b/content/dev/template.md
@@ -12,10 +12,10 @@ We have a mod template to make getting started easy. Adding dependencies will re
 ### Example usage
 `dotnet new vrisingmod -n NameOfYourMod --use-vcf --use-bloodstone --description "Description of your mod"`
 
-This will get you started with a mod named _NameOfYourMod_, using [Bloodstone]({{< relref "bloodstone" >}}) and [VampireCommandFramework](https://github.com/decaprime/VampireCommandFramework/) that has a sample server command to uncomment.
+This will get you started with a mod named _NameOfYourMod_, using [Bloodstone]({{% relref "bloodstone" %}}) and [VampireCommandFramework](https://github.com/decaprime/VampireCommandFramework/) that has a sample server command to uncomment.
 ### Optional Dependencies (add using the --use tag)
 - [VampireCommandFramework](https://github.com/decaprime/VampireCommandFramework/)
-- [Bloodstone]({{< relref "bloodstone" >}})
+- [Bloodstone]({{% relref "bloodstone" %}})
 
 
 ---

--- a/content/user/Mod_Install.md
+++ b/content/user/Mod_Install.md
@@ -5,7 +5,7 @@ weight: 2
 
 # Manually installing Mods
 
-If you're manually installing mods, you need to install BepInEx first. Reference [this page]({{< relref "user/bepinex_install" >}}) if you have not completed this step.
+If you're manually installing mods, you need to install BepInEx first. Reference [this page]({{% relref "user/bepinex_install" %}}) if you have not completed this step.
 Do remember that BepInEx will take some time to generate all of the files, so give it time on first boot up and after any game hotfixes.
 
 ### Dependencies

--- a/content/user/_index.md
+++ b/content/user/_index.md
@@ -9,8 +9,8 @@ disableToc: true
 - Support: Check out support channels in the discord or in the mod's readme
 
 ## Installation
-- [Manual BepInEx Installation]({{< relref "user/bepinex_install" >}})
-- [Manual Mod Installation]({{< relref "user/Mod_Install" >}})
-- [Using Server Mods in-game]({{< relref "user/Using_Server_Mods" >}})
+- [Manual BepInEx Installation]({{% relref "user/bepinex_install" %}})
+- [Manual Mod Installation]({{% relref "user/Mod_Install" %}})
+- [Using Server Mods in-game]({{% relref "user/Using_Server_Mods" %}})
 
-### If you wish to play an earlier version of V Rising: [Client Rollback]({{< relref "user/client_rollback" >}})
+### If you wish to play an earlier version of V Rising: [Client Rollback]({{% relref "user/client_rollback" %}})


### PR DESCRIPTION
## Summary
- convert `relref` shortcodes to raw-output form in development and user documentation

## Testing
- `./scripts/dev.sh build` *(fails: ERROR "theme-vampire.css": file not found)*


------
https://chatgpt.com/codex/tasks/task_e_689cc99747b8832d9504c336766102f1