### PR TITLE
Add pre-commit guard for Hugo ref shortcodes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: check-shortcode-syntax
+        name: Check for old-style Hugo ref shortcodes
+        entry: scripts/check_shortcode_syntax.sh
+        language: system
+        types: [markdown]
+        exclude: ^themes/

--- a/editing.md
+++ b/editing.md
@@ -25,3 +25,12 @@ __If you see something that can be contributed, please don't let worry about for
 
 ## Including Screenshots
 You can just paste images while inside the GitHub markdown editor and it will upload them and create the markup. These images work on the deployed wiki. Please only use images cropped to the subject area (e.g. Windows: `alt+print screen` - capture window, `Win+Shift+s` - Snipping Tool). 
+
+## Linking pages
+Use Hugo's `ref` and `relref` shortcodes with percent delimiters to link between pages:
+
+```md
+{{% ref "path/to/page.md" %}}
+```
+
+An automated pre-commit check blocks the older angle-bracket forms to keep links working.

--- a/scripts/check_shortcode_syntax.sh
+++ b/scripts/check_shortcode_syntax.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Scan provided files for old-style Hugo ref/relref shortcodes
+if grep -nE '\{\{<\s*(ref|relref)' "$@"; then
+  echo "ERROR: Found deprecated angle-bracket ref or relref shortcode. Use '{{% ref %}}' or '{{% relref %}}' instead." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- document preferred `% ref`/`% relref` Hugo shortcodes
- add pre-commit hook to fail on deprecated angle-bracket ref/relref shortcodes

## Testing
- `pre-commit run --files editing.md scripts/check_shortcode_syntax.sh .pre-commit-config.yaml`
- `hugo --minify` *(fails: error expanding "/prefabs/:contentbasename/": permalink ill-formed)*

------
https://chatgpt.com/codex/tasks/task_e_689cd8615878832d97078298ed940dc5