### PR TITLE
Add compiled vampire theme stylesheet

### DIFF
--- a/assets/css/theme-vampire.css
+++ b/assets/css/theme-vampire.css
@@ -1,0 +1,90 @@
+:root {
+  --body-background-color: #27262b;
+  --sidebar-color: #232226;
+  --border-color: #44434d;
+  --body-text-color: #e6e1e8;
+  --body-heading-color: #f5f6fa;
+  --nav-child-link-color: #959396;
+  --search-result-preview-color: #959396;
+  --link-color: #f74049;
+  --btn-primary-color: #e94c4c;
+  --base-button-color: #302d36;
+  --search-background-color: #302d36;
+  --table-background-color: #302d36;
+  --feedback-color: #1c1b1f;
+}
+
+.highlight .k, .highlight .kd {
+  color: #569CD6;
+}
+.highlight .nf {
+  color: #DCDCAA;
+}
+.highlight .p {
+  color: #D4D4D4;
+}
+.highlight .s {
+  color: #CE9178;
+}
+.highlight .n {
+  color: #9CDCFE;
+}
+.highlight .c1 {
+  color: #6A9955;
+}
+.highlight .kt {
+  color: #4EC9B0;
+}
+
+.logo {
+  display: flex;
+}
+.logo img {
+  width: 64px;
+  height: 64px;
+  padding: 5px;
+}
+.logo .title {
+  display: flex;
+  flex-direction: column;
+  align-self: center;
+  margin-left: 5px;
+}
+.logo .title .top {
+  font-size: 1rem;
+}
+.logo .title .bottom {
+  font-size: 1.125rem;
+}
+
+.prefab-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.prefab-list .prefab-item {
+  padding: 1em 2em;
+  margin: 0.1em;
+  width: 32%;
+  min-width: 100px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: #302d36;
+}
+@media (max-width: 900px) {
+  .prefab-list .prefab-item {
+    width: 48%;
+  }
+}
+@media (max-width: 500px) {
+  .prefab-list .prefab-item {
+    width: 100%;
+  }
+}
+.prefab-list .prefab-item:hover {
+  background: #44434d;
+}
+.prefab-list .prefab-item:active {
+  background: #27262b;
+}
+

--- a/assets/scss/vampire.scss
+++ b/assets/scss/vampire.scss
@@ -1,94 +1,80 @@
-// $grey-dk-000: #716d6d;
-// $grey-dk-200: darken($grey-dk-000, 15%);
-// $grey-dk-250: darken($grey-dk-000, 20%);
-// $grey-dk-300: darken($grey-dk-000, 25%);
+:root {
+  --body-background-color: #27262b;
+  --sidebar-color: #232226;
+  --border-color: #44434d;
+  --body-text-color: #e6e1e8;
+  --body-heading-color: #f5f6fa;
+  --nav-child-link-color: #959396;
+  --search-result-preview-color: #959396;
+  --link-color: #f74049;
+  --btn-primary-color: #e94c4c;
+  --base-button-color: #302d36;
+  --search-background-color: #302d36;
+  --table-background-color: #302d36;
+  --feedback-color: #1c1b1f;
+}
 
-$body-background-color: $grey-dk-300;
-$sidebar-color: darken($grey-dk-300, 1.5%);
-$border-color: $grey-dk-200;
-$body-text-color: $grey-lt-300;
-$body-heading-color: $grey-lt-000;
-$nav-child-link-color: $grey-dk-000;
-$search-result-preview-color: $grey-dk-000;
-$link-color: #f74049;
-$btn-primary-color: $red-200;
-$base-button-color: $grey-dk-250;
-$search-background-color: $grey-dk-250;
-$table-background-color: $grey-dk-250;
-$feedback-color: darken($sidebar-color, 3%);
-
-// The following highlight theme is more legible than that used for the light color scheme
-
-// @import "./vendor/OneDarkJekyll/syntax-one-dark";
-// $code-background-color: #282c34;
-
-//@import "./vendor/OneDarkJekyll/syntax-one-dark-vivid";
-
-$code-background-color: #31343f;
 .highlight {
-    .k, .kd { color: #569CD6; }  // keywords
-    .nf { color: #DCDCAA; }      // method names
-    .p { color: #D4D4D4; }       // punctuation
-    .s { color: #CE9178; }       // strings
-    .n { color: #9CDCFE; }       // parameters
-    .c1 { color: #6A9955; }      // comments
-    .kt { color: #4EC9B0; }      // types
-  }
-
-// @import "./vendor/OneDarkJekyll/syntax-firewatch";
-// $code-background-color: #282c34;
-
-// @import "./vendor/OneDarkJekyll/syntax-firewatch-green";
-// $code-background-color: #282c34;
+  .k, .kd { color: #569CD6; }
+  .nf { color: #DCDCAA; }
+  .p { color: #D4D4D4; }
+  .s { color: #CE9178; }
+  .n { color: #9CDCFE; }
+  .c1 { color: #6A9955; }
+  .kt { color: #4EC9B0; }
+}
 
 .logo {
+  display: flex;
+
+  img {
+    width: 64px;
+    height: 64px;
+    padding: 5px;
+  }
+
+  .title {
     display: flex;
+    flex-direction: column;
+    align-self: center;
+    margin-left: 5px;
 
-    img {
-        width: 64px;
-        height: 64px;
-        padding: 5px;
+    .top {
+      font-size: 1rem;
     }
 
-    .title {
-        display: flex;
-        flex-direction: column;
-        align-self: center;
-        margin-left: 5px;
-
-        .top {
-            @extend .fs-5;
-        }
-
-        .bottom {
-            @extend .fs-6;
-        }
+    .bottom {
+      font-size: 1.125rem;
     }
+  }
 }
 
 .prefab-list {
-    display:flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    .prefab-item {
-        padding: 1em 2em;
-        margin: 0.1em;
-        width: 32%;
-        @media (max-width: 900px) {
-            width: 48%;
-        }
-        @media (max-width: 500px) {
-            width: 100%;
-        }
-        min-width: 100px;
-        border: 1px solid transparent;
-        border-radius: 5px;
-        background: $grey-dk-250;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  .prefab-item {
+    padding: 1em 2em;
+    margin: 0.1em;
+    width: 32%;
+    @media (max-width: 900px) {
+      width: 48%;
     }
-    :hover {
-        background: $grey-dk-200;
+    @media (max-width: 500px) {
+      width: 100%;
     }
-    :active{
-        background: $grey-dk-300;
-    }
+    min-width: 100px;
+    border: 1px solid transparent;
+    border-radius: 5px;
+    background: #302d36;
+  }
+
+  .prefab-item:hover {
+    background: #44434d;
+  }
+
+  .prefab-item:active {
+    background: #27262b;
+  }
 }

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -10,6 +10,9 @@ git submodule update --init --recursive
 # Generate prefab file list
 python scripts/build_prefab_files.py
 
+# Build custom stylesheets
+npx --yes sass assets/css/theme-vampire.scss assets/css/theme-vampire.css
+
 switch ($Action) {
     'serve' { hugo server }
     'build' { hugo }

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -18,6 +18,9 @@ git submodule update --init --recursive
 # Generate prefab file list
 python scripts/build_prefab_files.py
 
+# Build custom stylesheets
+npx --yes sass assets/css/theme-vampire.scss assets/css/theme-vampire.css
+
 case "$action" in
   serve)
     hugo server


### PR DESCRIPTION
## Summary
- add self-contained vampire SCSS and compiled CSS
- compile SCSS before Hugo runs in dev scripts

## Testing
- `pre-commit run --files assets/scss/vampire.scss assets/css/theme-vampire.scss assets/css/theme-vampire.css scripts/dev.sh scripts/dev.ps1`
- `./scripts/dev.sh build` *(fails: error expanding "/prefabs/:contentbasename/": permalink ill-formed)*

------
https://chatgpt.com/codex/tasks/task_e_689cf4b81f8c832d8cbced20d2daceff