### PR TITLE
Check for npx before compiling Sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository contains the source for the V Rising Modding Wiki. It is built w
 * [Hugo](https://gohugo.io/) (extended version recommended)
 * [Python 3](https://www.python.org/)
 * [Git](https://git-scm.com/) with submodule support
+* [Node.js](https://nodejs.org/) (provides `npx` for SCSS-to-CSS compilation)
 
 ### Clone and setup
 
@@ -48,3 +49,5 @@ On Windows PowerShell:
 ```
 
 See [editing.md](editing.md) for guidelines on contributing.
+
+If Node.js is not available, any Sass compiler can be used to convert `assets/css/theme-vampire.scss` to `assets/css/theme-vampire.css` before running the scripts.

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -11,7 +11,15 @@ git submodule update --init --recursive
 python scripts/build_prefab_files.py
 
 # Build custom stylesheets
-npx --yes sass assets/css/theme-vampire.scss assets/css/theme-vampire.css
+$npx = Get-Command npx -ErrorAction SilentlyContinue
+$sass = Get-Command sass -ErrorAction SilentlyContinue
+if ($npx) {
+    npx --yes sass assets/css/theme-vampire.scss assets/css/theme-vampire.css
+} elseif ($sass) {
+    sass assets/css/theme-vampire.scss assets/css/theme-vampire.css
+} else {
+    Write-Host "npx or sass not found; skipping Sass compilation"
+}
 
 switch ($Action) {
     'serve' { hugo server }

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -19,7 +19,13 @@ git submodule update --init --recursive
 python scripts/build_prefab_files.py
 
 # Build custom stylesheets
-npx --yes sass assets/css/theme-vampire.scss assets/css/theme-vampire.css
+if command -v npx >/dev/null; then
+  npx --yes sass assets/css/theme-vampire.scss assets/css/theme-vampire.css
+elif command -v sass >/dev/null; then
+  sass assets/css/theme-vampire.scss assets/css/theme-vampire.css
+else
+  echo "npx or sass not found; skipping Sass compilation" >&2
+fi
 
 case "$action" in
   serve)


### PR DESCRIPTION
## Summary
- Handle absent `npx` in `scripts/dev.sh` and `scripts/dev.ps1`, with optional `sass` fallback
- Document Node.js requirement for SCSS compilation and Sass fallback

## Testing
- `./scripts/dev.sh build` *(fails: Error: error building site: failed to create resource spec: error expanding "/prefabs/:contentbasename/": permalink ill-formed)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_689d20e37cec832dbd6b5d4ad6e98922