### PR TITLE
Add Hugo base layout scaffold

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -1,0 +1,1 @@
+@import "vampire";

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+  <head>
+    {{ partial "head.html" . }}
+    {{ $styles := resources.Get "scss/app.scss" | resources.ToCSS | resources.Fingerprint }}
+    <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
+  </head>
+  <body>
+    <header class="jtd-header">
+      {{ partial "search.html" . }}
+    </header>
+    <div class="jtd-shell">
+      <aside class="jtd-sidebar">
+        <div class="sticky">
+          {{ partial "sidebar.html" . }}
+        </div>
+      </aside>
+      <main class="jtd-content">
+        {{ block "main" . }}{{ end }}
+      </main>
+    </div>
+    <footer class="jtd-footer">
+      {{ partial "footer.html" . }}
+    </footer>
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,0 +1,1 @@
+{{/* Site-wide scripts placeholder */}}

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,0 +1,3 @@
+<div class="search">
+  <input type="search" id="search-input" placeholder="Search...">
+</div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,0 +1,7 @@
+<nav class="sidebar-nav">
+  <ul>
+    {{ range .Site.RegularPages }}
+      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  </ul>
+</nav>


### PR DESCRIPTION
## Summary
- add base layout using jtd scaffolding
- process SCSS through Hugo asset pipeline
- stub out sidebar, search, and scripts partials

## Testing
- `hugo server`
- `pre-commit run --files assets/scss/app.scss layouts/_default/baseof.html layouts/partials/scripts.html layouts/partials/search.html layouts/partials/sidebar.html`


------
https://chatgpt.com/codex/tasks/task_e_689d456f399c832d8237407504ee56b5