### PR TITLE
feat: add collapsible sidebar navigation

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -1,1 +1,8 @@
 @import "vampire";
+
+.jtd-sidebar .sticky {
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+  overflow-y: auto;
+}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,7 +1,21 @@
-<nav class="sidebar-nav">
-  <ul>
-    {{ range .Site.RegularPages }}
-      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
-    {{ end }}
-  </ul>
+<nav class="jtd-nav">
+  {{ $current := . }}
+  {{ range .Site.Menus.main }}
+    {{ $isActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
+    <details {{ if $isActive }}open{{ end }}>
+      <summary>
+        <a href="{{ .URL }}" class="{{ if $isActive }}active{{ end }}">{{ .Name }}</a>
+      </summary>
+      {{ if .HasChildren }}
+        <ul>
+          {{ range .Children }}
+            {{ $childActive := or ($current.IsMenuCurrent "main" .) ($current.HasMenuCurrent "main" .) }}
+            <li>
+              <a href="{{ .URL }}" class="{{ if $childActive }}active{{ end }}">{{ .Name }}</a>
+            </li>
+          {{ end }}
+        </ul>
+      {{ end }}
+    </details>
+  {{ end }}
 </nav>


### PR DESCRIPTION
## Summary
- build sidebar navigation from `.Site.Menus.main` using collapsible `<details>` groups
- make sidebar sticky and scrollable in CSS

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_689d4f1e25f8832db35385ac0da391d1