### PR TITLE
Add anchor links to headings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,3 +306,5 @@ components.yml
 # Generated prefab file list
 data/prefab_files.yml
 
+resources/_gen/
+

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -78,6 +78,17 @@ a:hover {
   text-decoration: underline;
 }
 
+.anchor {
+  visibility: hidden;
+  margin-left: .5rem;
+  text-decoration: none;
+}
+
+h2:hover .anchor,
+h3:hover .anchor {
+  visibility: visible;
+}
+
 // Table styles
  table {
   width: 100%;

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,7 @@
+{{ define "main" }}
+  <h1>{{ .Title }}</h1>
+  {{ $pattern := `(<h[23] id="([^"]+)">)` }}
+  {{ $replace := `${1}<a class="anchor" href="#${2}">#</a> ` }}
+  {{ $content := .Content | replaceRE $pattern $replace | safeHTML }}
+  {{ $content }}
+{{ end }}


### PR DESCRIPTION
## Summary
- inject anchor links into h2/h3 headings via replaceRE
- style `.anchor` links to appear on heading hover
- ignore generated Hugo resources

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_689d57a2fdd4832d9f65708049ac59b7