### PR TITLE
Add header branding and Thunderstore link

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -18,6 +18,64 @@
   background: var(--sidebar-color);
   color: var(--body-heading-color);
 }
+
+.jtd-header__inner {
+  max-width: var(--content-max-width);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0 1rem;
+}
+
+.jtd-brand {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  text-decoration: none;
+  color: var(--body-heading-color);
+}
+
+.jtd-logo {
+  width: 36px;
+  height: 36px;
+}
+
+.jtd-title {
+  font-weight: 700;
+}
+
+.jtd-search {
+  flex: 1;
+}
+
+.jtd-search input[type="search"] {
+  width: 100%;
+}
+
+.jtd-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: .4rem .8rem;
+  border-radius: .5rem;
+  background: var(--btn-primary-color);
+  color: #fff;
+  text-decoration: none;
+}
+
+.jtd-cta:hover {
+  opacity: .85;
+}
+
+.jtd-toplink {
+  margin-right: 1rem;
+  color: var(--nav-child-link-color);
+}
+
+.jtd-toplink:hover {
+  color: var(--link-color);
+}
 .jtd-sidebar {
   width: var(--sidebar-width);
   padding: 1rem;

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -5,9 +5,19 @@
     {{ $styles := resources.Get "scss/app.scss" | resources.ToCSS | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
   </head>
-  <body>
+  <body class="jtd-dark">
     <header class="jtd-header">
-      {{ partial "search.html" . }}
+      <div class="jtd-header__inner">
+        <a class="jtd-brand" href="{{ "/" | relURL }}">
+          <img class="jtd-logo" src="{{ "images/logo.png" | relURL }}" alt="{{ .Site.Title }}">
+          <span class="jtd-title">{{ .Site.Title }}</span>
+        </a>
+        <a class="jtd-toplink" href="https://thunderstore.io/c/v-rising/" target="_blank" rel="noopener">V Rising Thunderstore</a>
+        <form class="jtd-search" id="search-form" role="search">
+          <input id="search-input" type="search" placeholder="Search V Rising Mod Wiki" autocomplete="off">
+        </form>
+        <a class="jtd-cta" href="{{ .Site.Params.discordURL }}" target="_blank" rel="noopener">Join Discord</a>
+      </div>
     </header>
     <div class="jtd-shell">
       <aside class="jtd-sidebar">
@@ -23,5 +33,6 @@
       {{ partial "footer.html" . }}
     </footer>
     {{ partial "scripts.html" . }}
+    {{ partial "search.html" . }}
   </body>
 </html>

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,5 +1,12 @@
+{{- /* Pagefind UI */ -}}
+<script defer src="/pagefind/pagefind-ui.js"></script>
 <link rel="stylesheet" href="/pagefind/pagefind-ui.css">
-<form id="search-form" class="search">
-  <input type="search" id="search-input" placeholder="Search...">
-</form>
-<script src="/pagefind/pagefind-ui.js"></script>
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  new PagefindUI({
+    element: "#search-form",
+    showImages: false,
+    resetStyles: true
+  });
+});
+</script>

--- a/static/images/logo.png
+++ b/static/images/logo.png
@@ -1,0 +1,1 @@
+mod_logo_red_purple.png


### PR DESCRIPTION
## Summary
- add site logo and branding header with Thunderstore link and Discord CTA
- style header elements including top link and CTA
- load Pagefind UI for top search form

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_689d41358740832db7ade065e6cdd1ce