### PR TITLE
Remove duplicate Thunderstore link configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,8 +26,6 @@ params:
     adapter:
       identifier: lunr
   focus_shortcut_key: "k"
-  aux_links:
-    "V Rising Thunderstore": "https://thunderstore.io/c/v-rising/"
   enable_copy_code_button: true
   discordURL: "https://discord.gg/your-link"
   callouts:


### PR DESCRIPTION
## Summary
- choose `baseof.html` as the source for the Thunderstore link
- drop unused `aux_links` entry from `config.yaml`

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_689d6d0b8a50832d99aad890d2120a47