### PR TITLE
Remove Lunr search adapter for Pagefind

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,9 +22,7 @@ sitemap:
 params:
   back_to_top: true
   back_to_top_text: "Back to top"
-  search:
-    adapter:
-      identifier: lunr
+  search: {}
   focus_shortcut_key: "k"
   enable_copy_code_button: true
   discordURL: "https://discord.gg/your-link"


### PR DESCRIPTION
## Summary
- remove Lunr search adapter so site can use Pagefind

## Testing
- `pre-commit run --files config.yaml`
- `hugo`
- `npx pagefind --site public`
- `curl -s http://localhost:8000/pagefind/pagefind-entry.json`
- `curl -s http://localhost:8000/dev/development_setup/ | rg pagefind | head`
- `curl -s http://localhost:8000/dev/development_setup/ | rg 'jtd-search' | head`


------
https://chatgpt.com/codex/tasks/task_e_689d7079cbac832d8533c2d0d60e8b07