### PR TITLE
Avoid duplicate H1 headers

### DIFF
--- a/content/user/Mod_Install.md
+++ b/content/user/Mod_Install.md
@@ -69,5 +69,5 @@ It should look much the same, with other things in the folder.
 
 
 
-# Start game/server after moving all files
+## Start game/server after moving all files
 Your server should start with mods installed correctly. If it does not, check your `BepInEx/LogOutput.log` to see what is having problems loading. You will need this if you seek technical support from the discord.

--- a/content/user/bepinex_install.md
+++ b/content/user/bepinex_install.md
@@ -39,5 +39,5 @@ Same as above, except the folder is `VRisingDedicatedServer`
 ![image](https://github.com/decaprime/VRising-Modding/assets/62450933/18d1c23b-5226-4cc8-93fa-90934934daf2)
 
 
-# Start game/server after moving all files
+## Start game/server after moving all files
 This will take a few minutes while BepInEx prepares to load mods for the game. This process will happen on clean installs and game updates. You can tell if it's in the correct place because you will have a `BepInEx/LogOutput.log` generated and if your running a game client you will see a console Window also open with the BepInEx output.

--- a/content/user/game_update.md
+++ b/content/user/game_update.md
@@ -7,7 +7,7 @@ draft: true
 
 # Thunderstore releases: BepInEx and VCF have been updated to [thunderstore](https://thunderstore.io/c/v-rising/). This page is deprecated. 5/17
 
-# RE: 1.1 - Updated 4/27
+## RE: 1.1 - Updated 4/27
 Previous versions of mods and BepInEx do not work with the Oakveil game update. There will be an announcement in discord and versions published to Thunderstore when they are ready. We have a BepInEx release candidate that we need developers to update and test their mods with.
 {{% notice warning "A Note" %}}
 Please note Mods that are not yet updated may take some unknown amount of time to be updated to 1.1. We would like to remind all users who enjoy playing with mods to be patient and understand that modders are working on getting the mods updated and stable.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,4 @@
 {{ define "main" }}
-  <h1>{{ .Title }}</h1>
   {{ $pattern := `(<h[23] id="([^"]+)">)` }}
   {{ $replace := `${1}<a class="anchor" href="#${2}">#</a> ` }}
   {{ $content := .Content | replaceRE $pattern $replace | safeHTML }}


### PR DESCRIPTION
## Summary
- Remove automatic `<h1>` from the single page layout so content controls its own heading
- Demote extra top-level headings in user installation docs
- Adjust Oakveil update notice to use a subheading

## Testing
- `hugo`
- `rg -n '<h1' public/user/bepinex_install/index.html`
- `rg -n '<h1' public/user/mod_install/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689d74817880832d9eefb5ab8bb79d54