### PR TITLE
Add default layouts for home, list, and taxonomy pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+  <h1>{{ .Title }}</h1>
+  {{ if .Content }}
+    {{ .Content }}
+  {{ end }}
+  <ul>
+    {{ range .Pages }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  </ul>
+{{ end }}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+  <h1>{{ .Title }}</h1>
+  {{ if .Content }}
+    {{ .Content }}
+  {{ end }}
+  <ul>
+    {{ range .Pages }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  </ul>
+{{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,8 @@
+{{ define "main" }}
+  <h1>{{ .Title }}</h1>
+  <ul>
+    {{ range .Data.Terms }}
+    <li><a href="{{ .Page.RelPermalink }}">{{ .Page.Title }} ({{ .Count }})</a></li>
+    {{ end }}
+  </ul>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+  {{ if .Content }}
+    {{ .Content }}
+  {{ end }}
+  <ul>
+    {{ range .Sections }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  </ul>
+{{ end }}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,0 +1,5 @@
+{{- with .TableOfContents }}
+<div class="toc">
+  {{ . | safeHTML }}
+</div>
+{{- end }}


### PR DESCRIPTION
## Summary
- add home page template to display sections
- add list, taxonomy, and terms layouts to cover section and taxonomy kinds
- include toc partial for table-of-contents shortcode

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_689d75f11e60832d8c44379504f2d8f4