### PR TITLE
Use css.Sass for SCSS pipeline

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,7 +2,7 @@
 <html lang="{{ .Site.LanguageCode }}">
   <head>
     {{ partial "head.html" . }}
-    {{ $styles := resources.Get "scss/app.scss" | resources.ToCSS | resources.Fingerprint }}
+    {{ $styles := resources.Get "scss/app.scss" | css.Sass | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
   </head>
   <body class="jtd-dark">


### PR DESCRIPTION
## Summary
- replace deprecated `resources.ToCSS` with `css.Sass` in base layout

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_689d7da89748832d8431fd6942595fff