### PR TITLE
fix: use slug in prefab permalinks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ ignoreLogs:
   - warning-goldmark-raw-html
 
 permalinks:
-  prefabs: "/prefabs/:filename/"
+  prefabs: "/prefabs/:slug/"
 
 sitemap:
   changefreq: monthly


### PR DESCRIPTION
## Summary
- replace deprecated :filename token in prefabs permalink with :slug

## Testing
- `pre-commit run --files config.yaml`
- `hugo --minify` *(fails: can't evaluate field Sass in type interface {})*

------
https://chatgpt.com/codex/tasks/task_e_689d7ee9cf88832dac0d8d530dd00b9b