### PR TITLE
feat: add color palette overrides

### DIFF
--- a/assets/css/theme-vampire.scss
+++ b/assets/css/theme-vampire.scss
@@ -1,1 +1,2 @@
 @import "../scss/vampire";
+@import "../scss/colors";

--- a/assets/scss/_colors.scss
+++ b/assets/scss/_colors.scss
@@ -1,0 +1,25 @@
+:root {
+  --body-background-color: #27262b;
+  --sidebar-color: #232226;
+  --border-color: #44434d;
+  --body-text-color: #e6e1e8;
+  --body-heading-color: #f5f6fa;
+  --nav-child-link-color: #959396;
+  --search-result-preview-color: #959396;
+  --link-color: #f74049;
+  --btn-primary-color: #e94c4c;
+  --base-button-color: #302d36;
+  --search-background-color: #302d36;
+  --table-background-color: #302d36;
+  --feedback-color: #1c1b1f;
+}
+
+.highlight {
+  .k, .kd { color: #569CD6; }
+  .nf { color: #DCDCAA; }
+  .p { color: #D4D4D4; }
+  .s { color: #CE9178; }
+  .n { color: #9CDCFE; }
+  .c1 { color: #6A9955; }
+  .kt { color: #4EC9B0; }
+}


### PR DESCRIPTION
## Summary
- add dedicated `_colors.scss` with theme color variables and syntax highlighting colors
- include color overrides in `theme-vampire.scss` bundle

## Testing
- `pre-commit run --files assets/scss/_colors.scss assets/css/theme-vampire.scss`
- `hugo` *(fails: error expanding "/prefabs/:contentbasename/": permalink ill-formed)*

------
https://chatgpt.com/codex/tasks/task_e_689dd307bf0c832dab37d955fad5f95b