### PR TITLE
Normalize markdown titles

### DIFF
--- a/content/dev/_index.md
+++ b/content/dev/_index.md
@@ -1,8 +1,6 @@
 ---
 title: For Developers
 ---
-# For Developers
-
 ## Getting started
 Set up your [development environment](./development_setup/).
 

--- a/content/dev/bloodstone.md
+++ b/content/dev/bloodstone.md
@@ -1,13 +1,11 @@
 ---
-title: Wetstone -> Bloodstone
+title: Bloodstone
 hidden: true
 disableToc: true
 ---
 
 ![bloodstone-banner](https://i.imgur.com/Py0MwUL.png)
 
-
-# Bloodstone
 
 Bloodstone is a successor to Wetstone for Gloomrot and beyond. It's available on https://www.nuget.org/packages/VRising.Bloodstone/ and https://github.com/decaprime/Bloodstone . It's actively maintained and automated through CI/CD. Soon it will contain VampireCommandFramework and other ECS utilities to make getting started easier with a single file `Bloodstone.dll` dependency.
 

--- a/content/dev/development_setup.md
+++ b/content/dev/development_setup.md
@@ -1,9 +1,6 @@
 ---
 title: Development Environment Setup
 ---
-
-# Development Environment Setup
-
 Before starting development, you'll need to install and configure a few essential tools like an IDE, Git, and .NET to set up your development environment.
 
 ## Integrated Development Environment: Visual Studio

--- a/content/dev/gloomrot.md
+++ b/content/dev/gloomrot.md
@@ -4,8 +4,6 @@ hidden: true
 disableToc: true
 ---
 
-# Migrating plugins for glooomrot
-
 - BepInEx: [Thunderstore 1.668.5](https://v-rising.thunderstore.io/package/BepInEx/BepInExPack_V_Rising/)
 - Game Libs: [nuget](https://www.nuget.org/packages/VRising.Unhollowed.Client/)
 

--- a/content/dev/migration_guide.md
+++ b/content/dev/migration_guide.md
@@ -1,9 +1,6 @@
 ---
 title: Migration Guide for 1.1 Update
 ---
-
-# Migrating plugins for 1.1
-
 - BepInEx (TESTING): [RC2 1.733.2](https://github.com/decaprime/VRising-Modding/releases/tag/1.733.2)
 - VampireCommandFramework (TESTING): [VCF 0.0.999](https://github.com/Odjit/VampireCommandFramework/releases/tag/1.1)
 - Game Libs: [nuget](https://www.nuget.org/packages/VRising.Unhollowed.Client/)

--- a/content/dev/resources.md
+++ b/content/dev/resources.md
@@ -1,8 +1,6 @@
 ---
-title: Resources
+title: Mod Development Resources
 ---
-
-# Resources for Mod Developers
 
 ## Wiki Resources
 

--- a/content/dev/upload_to_thunderstore.md
+++ b/content/dev/upload_to_thunderstore.md
@@ -1,8 +1,6 @@
 ---
-title: Uploading To Thunderstore
+title: How to Upload Mods to Thunderstore
 ---
-
-# How to Upload Mods to Thunderstore for V Rising
 
 Uploading your mod to Thunderstore is a simple process, but it requires a few steps to ensure your mod is correctly packaged and ready for the community to enjoy.
 

--- a/content/prefabs/_index.md
+++ b/content/prefabs/_index.md
@@ -2,9 +2,6 @@
 layout: default
 title: Prefabs
 ---
-
-# Prefabs
-
 Prefabs are identifers often used in commands or configurations to refer to an object, item, effect, etc.
 
 

--- a/content/user/Mod_Install.md
+++ b/content/user/Mod_Install.md
@@ -3,7 +3,6 @@ title: Manual Mod Installation
 weight: 2
 ---
 
-# Manually installing Mods
 
 If you're manually installing mods, you need to install BepInEx first. Reference [this page]({{% relref "user/bepinex_install" %}}) if you have not completed this step.
 Do remember that BepInEx will take some time to generate all of the files, so give it time on first boot up and after any game hotfixes.
@@ -69,5 +68,5 @@ It should look much the same, with other things in the folder.
 
 
 
-# Start game/server after moving all files
+## Start game/server after moving all files
 Your server should start with mods installed correctly. If it does not, check your `BepInEx/LogOutput.log` to see what is having problems loading. You will need this if you seek technical support from the discord.

--- a/content/user/Using_Server_Mods.md
+++ b/content/user/Using_Server_Mods.md
@@ -1,9 +1,8 @@
 ---
-title: Using Server Mods in-game
+title: Use Server Mods In-Game
 weight: 3
 ---
 
-# How to use Server Mods In-Game
 - [Adding to the AdminList](#adding-to-the-adminlist)
 - [Authorizing yourself as an Admin in-game](#authorizing-yourself-as-an-admin-in-game)
 - [Enabling Console](#enabling-console)

--- a/content/user/_index.md
+++ b/content/user/_index.md
@@ -1,9 +1,8 @@
 ---
-title: For Users
+title: Mod User Guides
 disableToc: true
 ---
 
-# For users of mods
 - V Rising mods at Thunderstore: [https://v-rising.thunderstore.io/](https://v-rising.thunderstore.io/)
 - Discord: [V Rising Mod Community Discord](https://vrisingmods.com/discord)
 - Support: Check out support channels in the discord or in the mod's readme

--- a/content/user/bepinex_install.md
+++ b/content/user/bepinex_install.md
@@ -3,7 +3,6 @@ title: Manual BepInEx Installation
 weight: 1
 ---
 
-# Manually installing BepInEx
 
 If you're manually installing mods, you need to install BepInEx, you can find it on [thunderstore](https://v-rising.thunderstore.io/package/BepInEx/BepInExPack_V_Rising/). This page guides you through how to unzip the contents and put them in the correct location.
 
@@ -39,5 +38,5 @@ Same as above, except the folder is `VRisingDedicatedServer`
 ![image](https://github.com/decaprime/VRising-Modding/assets/62450933/18d1c23b-5226-4cc8-93fa-90934934daf2)
 
 
-# Start game/server after moving all files
+## Start game/server after moving all files
 This will take a few minutes while BepInEx prepares to load mods for the game. This process will happen on clean installs and game updates. You can tell if it's in the correct place because you will have a `BepInEx/LogOutput.log` generated and if your running a game client you will see a console Window also open with the BepInEx output.

--- a/content/user/client_rollback.md
+++ b/content/user/client_rollback.md
@@ -1,8 +1,7 @@
 ---
-title: How to rollback client
+title: Client Rollback
 ---
 
-# How to rollback the V Rising client to a previous version
 
 To roll back to the previous version, before 1.0, this is what you need to do:
 

--- a/content/user/game_update.md
+++ b/content/user/game_update.md
@@ -5,9 +5,10 @@ disableToc: true
 draft: true
 ---
 
-# Thunderstore releases: BepInEx and VCF have been updated to [thunderstore](https://thunderstore.io/c/v-rising/). This page is deprecated. 5/17
+## Thunderstore releases
+BepInEx and VCF have been updated to [Thunderstore](https://thunderstore.io/c/v-rising/). This page is deprecated. 5/17.
 
-# RE: 1.1 - Updated 4/27
+## RE: 1.1 - Updated 4/27
 Previous versions of mods and BepInEx do not work with the Oakveil game update. There will be an announcement in discord and versions published to Thunderstore when they are ready. We have a BepInEx release candidate that we need developers to update and test their mods with.
 {{% notice warning "A Note" %}}
 Please note Mods that are not yet updated may take some unknown amount of time to be updated to 1.1. We would like to remind all users who enjoy playing with mods to be patient and understand that modders are working on getting the mods updated and stable.


### PR DESCRIPTION
## Summary
- remove duplicated H1 headings from content markdown files
- refine front-matter titles for clarity and consistency
- ensure each page renders with a single, clear H1 title

## Testing
- `pre-commit run --files content/dev/_index.md content/dev/bloodstone.md content/dev/development_setup.md content/dev/gloomrot.md content/dev/migration_guide.md content/dev/resources.md content/dev/upload_to_thunderstore.md content/prefabs/_index.md content/user/Mod_Install.md content/user/Using_Server_Mods.md content/user/_index.md content/user/bepinex_install.md content/user/client_rollback.md content/user/game_update.md`

------
https://chatgpt.com/codex/tasks/task_e_689de4ce5d74832da06077f362166579