### PR TITLE
Add weight metadata for consistent navigation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ ignoreLogs:
   - warning-goldmark-raw-html
 
 permalinks:
-  prefabs: "/prefabs/:contentbasename/"
+  prefabs: "/prefabs/:filename/"
 
 sitemap:
   changefreq: monthly

--- a/content/dev/_index.md
+++ b/content/dev/_index.md
@@ -1,5 +1,6 @@
 ---
 title: For Developers
+weight: 0
 ---
 ## Getting started
 Set up your [development environment](./development_setup/).

--- a/content/dev/bloodstone.md
+++ b/content/dev/bloodstone.md
@@ -2,6 +2,7 @@
 title: Bloodstone
 hidden: true
 disableToc: true
+weight: 1
 ---
 
 ![bloodstone-banner](https://i.imgur.com/Py0MwUL.png)

--- a/content/dev/development_setup.md
+++ b/content/dev/development_setup.md
@@ -1,5 +1,6 @@
 ---
 title: Development Environment Setup
+weight: 2
 ---
 Before starting development, you'll need to install and configure a few essential tools like an IDE, Git, and .NET to set up your development environment.
 

--- a/content/dev/gloomrot.md
+++ b/content/dev/gloomrot.md
@@ -2,6 +2,7 @@
 title: Migration Guide for Gloomrot
 hidden: true
 disableToc: true
+weight: 3
 ---
 
 - BepInEx: [Thunderstore 1.668.5](https://v-rising.thunderstore.io/package/BepInEx/BepInExPack_V_Rising/)

--- a/content/dev/gpt_instructions.md
+++ b/content/dev/gpt_instructions.md
@@ -1,5 +1,6 @@
 ---
 title: GPT Instructions
+weight: 4
 ---
 
 ## V Rising Technical Guidelines and Best Practices - Instruction Set for C#(Rising)

--- a/content/dev/migration_guide.md
+++ b/content/dev/migration_guide.md
@@ -1,5 +1,6 @@
 ---
 title: Migration Guide for 1.1 Update
+weight: 5
 ---
 - BepInEx (TESTING): [RC2 1.733.2](https://github.com/decaprime/VRising-Modding/releases/tag/1.733.2)
 - VampireCommandFramework (TESTING): [VCF 0.0.999](https://github.com/Odjit/VampireCommandFramework/releases/tag/1.1)

--- a/content/dev/open-source.md
+++ b/content/dev/open-source.md
@@ -1,5 +1,6 @@
 ---
 title: Open Source Mods
+weight: 6
 ---
 
 <!--

--- a/content/dev/resources.md
+++ b/content/dev/resources.md
@@ -1,5 +1,6 @@
 ---
 title: Mod Development Resources
+weight: 7
 ---
 
 ## Wiki Resources

--- a/content/dev/template.md
+++ b/content/dev/template.md
@@ -1,5 +1,6 @@
 ---
 title: Templates
+weight: 8
 ---
 
 ## Template

--- a/content/dev/upload_to_thunderstore.md
+++ b/content/dev/upload_to_thunderstore.md
@@ -1,5 +1,6 @@
 ---
 title: How to Upload Mods to Thunderstore
+weight: 9
 ---
 
 Uploading your mod to Thunderstore is a simple process, but it requires a few steps to ensure your mod is correctly packaged and ready for the community to enjoy.

--- a/content/prefabs/AB.md
+++ b/content/prefabs/AB.md
@@ -1,4 +1,5 @@
 ---
 title: AB
 data_file: AB
+weight: 1
 ---

--- a/content/prefabs/AI.md
+++ b/content/prefabs/AI.md
@@ -1,4 +1,5 @@
 ---
 title: AI
 data_file: AI
+weight: 2
 ---

--- a/content/prefabs/Ability.md
+++ b/content/prefabs/Ability.md
@@ -1,4 +1,5 @@
 ---
 title: Ability
 data_file: Ability
+weight: 3
 ---

--- a/content/prefabs/Aim.md
+++ b/content/prefabs/Aim.md
@@ -1,4 +1,5 @@
 ---
 title: Aim
 data_file: Aim
+weight: 4
 ---

--- a/content/prefabs/All.md
+++ b/content/prefabs/All.md
@@ -1,4 +1,5 @@
 ---
 title: All
 data_file: All
+weight: 5
 ---

--- a/content/prefabs/Ascendancy.md
+++ b/content/prefabs/Ascendancy.md
@@ -1,4 +1,5 @@
 ---
 title: Ascendancy
 data_file: Ascendancy
+weight: 6
 ---

--- a/content/prefabs/BEH.md
+++ b/content/prefabs/BEH.md
@@ -1,4 +1,5 @@
 ---
 title: BEH
 data_file: BEH
+weight: 7
 ---

--- a/content/prefabs/BP.md
+++ b/content/prefabs/BP.md
@@ -1,4 +1,5 @@
 ---
 title: BP
 data_file: BP
+weight: 8
 ---

--- a/content/prefabs/Base.md
+++ b/content/prefabs/Base.md
@@ -1,4 +1,5 @@
 ---
 title: Base
 data_file: Base
+weight: 9
 ---

--- a/content/prefabs/Biome.md
+++ b/content/prefabs/Biome.md
@@ -1,4 +1,5 @@
 ---
 title: Biome
 data_file: Biome
+weight: 10
 ---

--- a/content/prefabs/Blood.md
+++ b/content/prefabs/Blood.md
@@ -1,4 +1,5 @@
 ---
 title: Blood
 data_file: Blood
+weight: 11
 ---

--- a/content/prefabs/Braziers.md
+++ b/content/prefabs/Braziers.md
@@ -1,4 +1,5 @@
 ---
 title: Braziers
 data_file: Braziers
+weight: 12
 ---

--- a/content/prefabs/Buff.md
+++ b/content/prefabs/Buff.md
@@ -1,4 +1,5 @@
 ---
 title: Buff
 data_file: Buff
+weight: 13
 ---

--- a/content/prefabs/CHAR.md
+++ b/content/prefabs/CHAR.md
@@ -1,4 +1,5 @@
 ---
 title: CHAR
 data_file: CHAR
+weight: 14
 ---

--- a/content/prefabs/CO.md
+++ b/content/prefabs/CO.md
@@ -1,4 +1,5 @@
 ---
 title: CO
 data_file: CO
+weight: 15
 ---

--- a/content/prefabs/Castle.md
+++ b/content/prefabs/Castle.md
@@ -1,4 +1,5 @@
 ---
 title: Castle
 data_file: Castle
+weight: 16
 ---

--- a/content/prefabs/Chain.md
+++ b/content/prefabs/Chain.md
@@ -1,4 +1,5 @@
 ---
 title: Chain
 data_file: Chain
+weight: 17
 ---

--- a/content/prefabs/Copper.md
+++ b/content/prefabs/Copper.md
@@ -1,4 +1,5 @@
 ---
 title: Copper
 data_file: Copper
+weight: 18
 ---

--- a/content/prefabs/Creature.md
+++ b/content/prefabs/Creature.md
@@ -1,4 +1,5 @@
 ---
 title: Creature
 data_file: Creature
+weight: 19
 ---

--- a/content/prefabs/Critter.md
+++ b/content/prefabs/Critter.md
@@ -1,4 +1,5 @@
 ---
 title: Critter
 data_file: Critter
+weight: 20
 ---

--- a/content/prefabs/Curtains.md
+++ b/content/prefabs/Curtains.md
@@ -1,4 +1,5 @@
 ---
 title: Curtains
 data_file: Curtains
+weight: 21
 ---

--- a/content/prefabs/Curve.md
+++ b/content/prefabs/Curve.md
@@ -1,4 +1,5 @@
 ---
 title: Curve
 data_file: Curve
+weight: 22
 ---

--- a/content/prefabs/DG.md
+++ b/content/prefabs/DG.md
@@ -1,4 +1,5 @@
 ---
 title: DG
 data_file: DG
+weight: 23
 ---

--- a/content/prefabs/DT.md
+++ b/content/prefabs/DT.md
@@ -1,4 +1,5 @@
 ---
 title: DT
 data_file: DT
+weight: 24
 ---

--- a/content/prefabs/Door.md
+++ b/content/prefabs/Door.md
@@ -1,4 +1,5 @@
 ---
 title: Door
 data_file: Door
+weight: 25
 ---

--- a/content/prefabs/Dye.md
+++ b/content/prefabs/Dye.md
@@ -1,4 +1,5 @@
 ---
 title: Dye
 data_file: Dye
+weight: 26
 ---

--- a/content/prefabs/Dynamic.md
+++ b/content/prefabs/Dynamic.md
@@ -1,4 +1,5 @@
 ---
 title: Dynamic
 data_file: Dynamic
+weight: 27
 ---

--- a/content/prefabs/Dynamics.md
+++ b/content/prefabs/Dynamics.md
@@ -1,4 +1,5 @@
 ---
 title: Dynamics
 data_file: Dynamics
+weight: 28
 ---

--- a/content/prefabs/EH.md
+++ b/content/prefabs/EH.md
@@ -1,4 +1,5 @@
 ---
 title: EH
 data_file: EH
+weight: 29
 ---

--- a/content/prefabs/Ease.md
+++ b/content/prefabs/Ease.md
@@ -1,4 +1,5 @@
 ---
 title: Ease
 data_file: Ease
+weight: 30
 ---

--- a/content/prefabs/Elris.md
+++ b/content/prefabs/Elris.md
@@ -1,4 +1,5 @@
 ---
 title: Elris
 data_file: Elris
+weight: 31
 ---

--- a/content/prefabs/Equip.md
+++ b/content/prefabs/Equip.md
@@ -1,4 +1,5 @@
 ---
 title: Equip
 data_file: Equip
+weight: 32
 ---

--- a/content/prefabs/Faction.md
+++ b/content/prefabs/Faction.md
@@ -1,4 +1,5 @@
 ---
 title: Faction
 data_file: Faction
+weight: 33
 ---

--- a/content/prefabs/Fake.md
+++ b/content/prefabs/Fake.md
@@ -1,4 +1,5 @@
 ---
 title: Fake
 data_file: Fake
+weight: 34
 ---

--- a/content/prefabs/Garden.md
+++ b/content/prefabs/Garden.md
@@ -1,4 +1,5 @@
 ---
 title: Garden
 data_file: Garden
+weight: 35
 ---

--- a/content/prefabs/Gloom.md
+++ b/content/prefabs/Gloom.md
@@ -1,4 +1,5 @@
 ---
 title: Gloom
 data_file: Gloom
+weight: 36
 ---

--- a/content/prefabs/Gravestone.md
+++ b/content/prefabs/Gravestone.md
@@ -1,4 +1,5 @@
 ---
 title: Gravestone
 data_file: Gravestone
+weight: 37
 ---

--- a/content/prefabs/Graveyard.md
+++ b/content/prefabs/Graveyard.md
@@ -1,4 +1,5 @@
 ---
 title: Graveyard
 data_file: Graveyard
+weight: 38
 ---

--- a/content/prefabs/Ground.md
+++ b/content/prefabs/Ground.md
@@ -1,4 +1,5 @@
 ---
 title: Ground
 data_file: Ground
+weight: 39
 ---

--- a/content/prefabs/Illusion.md
+++ b/content/prefabs/Illusion.md
@@ -1,4 +1,5 @@
 ---
 title: Illusion
 data_file: Illusion
+weight: 40
 ---

--- a/content/prefabs/Iron.md
+++ b/content/prefabs/Iron.md
@@ -1,4 +1,5 @@
 ---
 title: Iron
 data_file: Iron
+weight: 41
 ---

--- a/content/prefabs/Item.md
+++ b/content/prefabs/Item.md
@@ -1,4 +1,5 @@
 ---
 title: Item
 data_file: Item
+weight: 42
 ---

--- a/content/prefabs/Journal.md
+++ b/content/prefabs/Journal.md
@@ -1,4 +1,5 @@
 ---
 title: Journal
 data_file: Journal
+weight: 43
 ---

--- a/content/prefabs/Map.md
+++ b/content/prefabs/Map.md
@@ -1,4 +1,5 @@
 ---
 title: Map
 data_file: Map
+weight: 44
 ---

--- a/content/prefabs/Micro.md
+++ b/content/prefabs/Micro.md
@@ -1,4 +1,5 @@
 ---
 title: Micro
 data_file: Micro
+weight: 45
 ---

--- a/content/prefabs/Milo.md
+++ b/content/prefabs/Milo.md
@@ -1,4 +1,5 @@
 ---
 title: Milo
 data_file: Milo
+weight: 46
 ---

--- a/content/prefabs/Music.md
+++ b/content/prefabs/Music.md
@@ -1,4 +1,5 @@
 ---
 title: Music
 data_file: Music
+weight: 47
 ---

--- a/content/prefabs/NPCDeadeye.md
+++ b/content/prefabs/NPCDeadeye.md
@@ -1,4 +1,5 @@
 ---
 title: NPCDeadeye
 data_file: NPCDeadeye
+weight: 48
 ---

--- a/content/prefabs/PVP.md
+++ b/content/prefabs/PVP.md
@@ -1,4 +1,5 @@
 ---
 title: PVP
 data_file: PVP
+weight: 49
 ---

--- a/content/prefabs/Quarry.md
+++ b/content/prefabs/Quarry.md
@@ -1,4 +1,5 @@
 ---
 title: Quarry
 data_file: Quarry
+weight: 50
 ---

--- a/content/prefabs/Random.md
+++ b/content/prefabs/Random.md
@@ -1,4 +1,5 @@
 ---
 title: Random
 data_file: Random
+weight: 51
 ---

--- a/content/prefabs/Recipe.md
+++ b/content/prefabs/Recipe.md
@@ -1,4 +1,5 @@
 ---
 title: Recipe
 data_file: Recipe
+weight: 52
 ---

--- a/content/prefabs/Remainders.md
+++ b/content/prefabs/Remainders.md
@@ -1,4 +1,5 @@
 ---
 title: Remainders
 data_file: Remainders
+weight: 53
 ---

--- a/content/prefabs/Resource.md
+++ b/content/prefabs/Resource.md
@@ -1,4 +1,5 @@
 ---
 title: Resource
 data_file: Resource
+weight: 54
 ---

--- a/content/prefabs/Rock.md
+++ b/content/prefabs/Rock.md
@@ -1,4 +1,5 @@
 ---
 title: Rock
 data_file: Rock
+weight: 55
 ---

--- a/content/prefabs/SCT.md
+++ b/content/prefabs/SCT.md
@@ -1,4 +1,5 @@
 ---
 title: SCT
 data_file: SCT
+weight: 56
 ---

--- a/content/prefabs/Servant.md
+++ b/content/prefabs/Servant.md
@@ -1,4 +1,5 @@
 ---
 title: Servant
 data_file: Servant
+weight: 57
 ---

--- a/content/prefabs/Set.md
+++ b/content/prefabs/Set.md
@@ -1,4 +1,5 @@
 ---
 title: Set
 data_file: Set
+weight: 58
 ---

--- a/content/prefabs/Snapping.md
+++ b/content/prefabs/Snapping.md
@@ -1,4 +1,5 @@
 ---
 title: Snapping
 data_file: Snapping
+weight: 59
 ---

--- a/content/prefabs/Snow.md
+++ b/content/prefabs/Snow.md
@@ -1,4 +1,5 @@
 ---
 title: Snow
 data_file: Snow
+weight: 60
 ---

--- a/content/prefabs/Spell.md
+++ b/content/prefabs/Spell.md
@@ -1,4 +1,5 @@
 ---
 title: Spell
 data_file: Spell
+weight: 61
 ---

--- a/content/prefabs/Stash.md
+++ b/content/prefabs/Stash.md
@@ -1,4 +1,5 @@
 ---
 title: Stash
 data_file: Stash
+weight: 62
 ---

--- a/content/prefabs/Stat.md
+++ b/content/prefabs/Stat.md
@@ -1,4 +1,5 @@
 ---
 title: Stat
 data_file: Stat
+weight: 63
 ---

--- a/content/prefabs/Station.md
+++ b/content/prefabs/Station.md
@@ -1,4 +1,5 @@
 ---
 title: Station
 data_file: Station
+weight: 64
 ---

--- a/content/prefabs/Storm.md
+++ b/content/prefabs/Storm.md
@@ -1,4 +1,5 @@
 ---
 title: Storm
 data_file: Storm
+weight: 65
 ---

--- a/content/prefabs/Sun.md
+++ b/content/prefabs/Sun.md
@@ -1,4 +1,5 @@
 ---
 title: Sun
 data_file: Sun
+weight: 66
 ---

--- a/content/prefabs/TM.md
+++ b/content/prefabs/TM.md
@@ -1,4 +1,5 @@
 ---
 title: TM
 data_file: TM
+weight: 67
 ---

--- a/content/prefabs/Tech.md
+++ b/content/prefabs/Tech.md
@@ -1,4 +1,5 @@
 ---
 title: Tech
 data_file: Tech
+weight: 68
 ---

--- a/content/prefabs/Transmog.md
+++ b/content/prefabs/Transmog.md
@@ -1,4 +1,5 @@
 ---
 title: Transmog
 data_file: Transmog
+weight: 69
 ---

--- a/content/prefabs/Trees.md
+++ b/content/prefabs/Trees.md
@@ -1,4 +1,5 @@
 ---
 title: Trees
 data_file: Trees
+weight: 70
 ---

--- a/content/prefabs/UC.md
+++ b/content/prefabs/UC.md
@@ -1,4 +1,5 @@
 ---
 title: UC
 data_file: UC
+weight: 71
 ---

--- a/content/prefabs/Undead.md
+++ b/content/prefabs/Undead.md
@@ -1,4 +1,5 @@
 ---
 title: Undead
 data_file: Undead
+weight: 72
 ---

--- a/content/prefabs/Unholy.md
+++ b/content/prefabs/Unholy.md
@@ -1,4 +1,5 @@
 ---
 title: Unholy
 data_file: Unholy
+weight: 73
 ---

--- a/content/prefabs/VBloodNames.md
+++ b/content/prefabs/VBloodNames.md
@@ -2,6 +2,7 @@
 layout: default
 title: VBlood Names
 data_file: VBloodNames
+weight: 74
 ---
 
 {{% vblood_names_table %}}

--- a/content/prefabs/VIB.md
+++ b/content/prefabs/VIB.md
@@ -1,4 +1,5 @@
 ---
 title: VIB
 data_file: VIB
+weight: 75
 ---

--- a/content/prefabs/VM.md
+++ b/content/prefabs/VM.md
@@ -1,4 +1,5 @@
 ---
 title: VM
 data_file: VM
+weight: 76
 ---

--- a/content/prefabs/Vampire.md
+++ b/content/prefabs/Vampire.md
@@ -1,4 +1,5 @@
 ---
 title: Vampire
 data_file: Vampire
+weight: 77
 ---

--- a/content/prefabs/Water.md
+++ b/content/prefabs/Water.md
@@ -1,4 +1,5 @@
 ---
 title: Water
 data_file: Water
+weight: 78
 ---

--- a/content/prefabs/Weapon.md
+++ b/content/prefabs/Weapon.md
@@ -1,4 +1,5 @@
 ---
 title: Weapon
 data_file: Weapon
+weight: 79
 ---

--- a/content/prefabs/Wild.md
+++ b/content/prefabs/Wild.md
@@ -1,4 +1,5 @@
 ---
 title: Wild
 data_file: Wild
+weight: 80
 ---

--- a/content/prefabs/ZM.md
+++ b/content/prefabs/ZM.md
@@ -1,4 +1,5 @@
 ---
 title: ZM
 data_file: ZM
+weight: 81
 ---

--- a/content/prefabs/_index.md
+++ b/content/prefabs/_index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Prefabs
+weight: 0
 ---
 Prefabs are identifers often used in commands or configurations to refer to an object, item, effect, etc.
 

--- a/content/user/_index.md
+++ b/content/user/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Mod User Guides
 disableToc: true
+weight: 0
 ---
 
 - V Rising mods at Thunderstore: [https://v-rising.thunderstore.io/](https://v-rising.thunderstore.io/)

--- a/content/user/client_rollback.md
+++ b/content/user/client_rollback.md
@@ -1,5 +1,6 @@
 ---
 title: Client Rollback
+weight: 4
 ---
 
 

--- a/content/user/game_update.md
+++ b/content/user/game_update.md
@@ -3,6 +3,7 @@ title: Oakveil Game Update
 hidden: true
 disableToc: true
 draft: true
+weight: 5
 ---
 
 ## Thunderstore releases

--- a/content/user/gloomrot_mods.md
+++ b/content/user/gloomrot_mods.md
@@ -1,6 +1,7 @@
 ---
 title: Gloomrot Mod Status
 hidden: true
+weight: 6
 ---
 
 ## 🥳 We've released on Thunderstore

--- a/layouts/partials/custom-header.html
+++ b/layouts/partials/custom-header.html
@@ -9,21 +9,27 @@
 {{- $filePath := "css/theme-vampire.css" }}
 {{- with (resources.Get (printf "/%s" $filePath)) }}
   <link href="{{ .RelPermalink }}{{ $assetBusting }}" rel="stylesheet">
-{{- else if (fileExists (printf "/static/%s" $filePath)) }}
-  <link href="{{ printf "%s" $filePath | relURL }}{{ $assetBusting }}" rel="stylesheet">
+{{- else }}
+  {{- if (fileExists (printf "/static/%s" $filePath)) }}
+    <link href="{{ printf "%s" $filePath | relURL }}{{ $assetBusting }}" rel="stylesheet">
+  {{- end }}
 {{- end }}
 
 {{- $filePath := "css/custom.css" }}
 {{- with (resources.Get (printf "/%s" $filePath)) }}
   <link href="{{ .RelPermalink }}{{ $assetBusting }}" rel="stylesheet">
-{{- else if (fileExists (printf "/static/%s" $filePath)) }}
-  <link href="{{ printf "%s" $filePath | relURL }}{{ $assetBusting }}" rel="stylesheet">
+{{- else }}
+  {{- if (fileExists (printf "/static/%s" $filePath)) }}
+    <link href="{{ printf "%s" $filePath | relURL }}{{ $assetBusting }}" rel="stylesheet">
+  {{- end }}
 {{- end }}
 
 {{- $filePath := "js/custom.js" }}
 {{- with (resources.Get (printf "/%s" $filePath)) }}
   <script src="{{ .RelPermalink }}{{ $assetBusting }}" defer></script>
-{{- else if (fileExists (printf "/static/%s" $filePath)) }}
-  <script src="{{ printf "%s" $filePath | relURL }}{{ $assetBusting }}" defer></script>
+{{- else }}
+  {{- if (fileExists (printf "/static/%s" $filePath)) }}
+    <script src="{{ printf "%s" $filePath | relURL }}{{ $assetBusting }}" defer></script>
+  {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Summary
- add `weight` front matter across developer, prefab, and user guides
- set prefabs permalink to use `:filename`
- rework custom-header partial to avoid invalid `else if`

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_689df25ec444832d87d20a7771017f3a