### PR TITLE
Use GitHub Pages domain

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-baseURL: "https://wiki.vrisingmods.com/"
+baseURL: "https://mfoltz.github.io/"
 title: "V Rising Mod Wiki"
 description: "Information about mods for the game V Rising: How to build, debug, and publish your mods."
 theme: "hugo-theme-relearn"


### PR DESCRIPTION
## Summary
- point site baseURL to https://mfoltz.github.io for GitHub Pages hosting

## Testing
- `pre-commit run --files config.yaml`
- `./scripts/dev.sh build`


------
https://chatgpt.com/codex/tasks/task_e_689e17a239dc832db4d7eaa261f6355a