### PR TITLE
Fix dev script job paths

### DIFF
--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -9,8 +9,13 @@ $shade = [char]0x2591
 $total = if ($Action -eq 'serve') { 3 } else { 4 }
 $activity = if ($Action -eq 'serve') { '✨ Hugo Server' } else { '🏗️ Hugo Build' }
 
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..'))
 $requiredVersion = [Version]'0.126.3'
-$hugoDir = Join-Path (Join-Path $PSScriptRoot '..') 'build/hugo'
+$hugoDir = Join-Path $repoRoot 'build/hugo'
+
+if (-not (Get-Command Start-ThreadJob -ErrorAction SilentlyContinue)) {
+    Import-Module ThreadJob
+}
 
 function Ensure-Hugo {
     param([Version]$Required)
@@ -74,7 +79,11 @@ function Invoke-Step {
 
     $spinner = @('⣾','⣽','⣻','⢿','⡿','⣟','⣯','⣷')
     $barLength = 20
-    $job = Start-Job -ScriptBlock $Script
+    $job = Start-ThreadJob -ScriptBlock {
+        param($innerScript, $repoRoot)
+        Set-Location $repoRoot
+        & $innerScript
+    } -ArgumentList $Script, $repoRoot
     $i = 0
     while (-not (Wait-Job $job -Timeout 1)) {
         $frame = $spinner[$i % $spinner.Count]


### PR DESCRIPTION
## Summary
- Set `$repoRoot` in `scripts/dev.ps1` and use it for job working directories
- Ensure background steps run from repository root via `Start-ThreadJob`

## Testing
- `pwsh -NoLogo -File ./scripts/dev.ps1 serve`

------
https://chatgpt.com/codex/tasks/task_e_689e1bb79a2c832d8e82b0cc9fa1b0e0