### PR TITLE
Use content basename for prefab permalinks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ ignoreLogs:
   - warning-goldmark-raw-html
 
 permalinks:
-  prefabs: "/prefabs/:filename/"
+  prefabs: "/prefabs/:contentbasename/"
 
 sitemap:
   changefreq: monthly


### PR DESCRIPTION
## Summary
- resolve Hugo warning by switching prefab permalinks to `:contentbasename`

## Testing
- `python -m pre_commit run --files config.yaml`
- `./scripts/dev.sh build`


------
https://chatgpt.com/codex/tasks/task_e_689e2766c3a8832d8d93bbad4a6a7964