### PR TITLE
Move prefab listing to template

### DIFF
--- a/content/prefabs/_index.md
+++ b/content/prefabs/_index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Prefabs
 weight: 0
 ---
@@ -8,10 +7,3 @@ Prefabs are identifers often used in commands or configurations to refer to an o
 
 Full list here **(warning large file)**: [all prefabs](./All) also the remainder of the prefabs with fewer than 10 in a category into [remainders prefabs](./Remainders). [Vblood Prefabs by Name](./VBloodNames).
 
-<div class="prefab-list">
-  {{ range $name, $prefab := site.Data.prefabs }}
-    {{ if ne $name "All" }}
-      <a class="prefab-item" href="{{ (printf "/prefabs/%s" $name) | relURL }}"><b>{{ $name }}</b> ({{ len $prefab }})</a>
-    {{ end }}
-  {{ end }}
-</div>

--- a/layouts/prefabs/list.html
+++ b/layouts/prefabs/list.html
@@ -1,0 +1,27 @@
+{{ define "storeOutputFormat" }}
+  {{- .Store.Set "relearnOutputFormat" "HTML" }}
+{{ end }}
+
+{{ define "main" }}
+<h1>{{ .Title }} Prefabs</h1>
+
+{{ .Content }}
+<table>
+  <thead>
+    <tr>
+      <th>Category</th>
+      <th>Count</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{ range $name, $prefab := site.Data.prefabs }}
+      {{ if ne $name "All" }}
+      <tr>
+        <td><a href="{{ (printf "/prefabs/%s" $name) | relURL }}"><b>{{ $name }}</b></a></td>
+        <td>{{ len $prefab }}</td>
+      </tr>
+      {{ end }}
+    {{ end }}
+  </tbody>
+</table>
+{{ end }}


### PR DESCRIPTION
## Summary
- render prefab categories and counts in a dedicated list template
- simplify prefabs index markdown

## Testing
- `pre-commit run --files content/prefabs/_index.md layouts/prefabs/list.html`
- `hugo --quiet` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e35d9904c832d90a657fbc75b09e0