### PR TITLE
Generate prefab pages from JSON data

### DIFF
--- a/layouts/prefabs/single.html
+++ b/layouts/prefabs/single.html
@@ -6,7 +6,6 @@
 <h1>{{ .Title }} Prefabs</h1>
 
 {{ $prefab_data := index site.Data.prefabs .Params.data_file }}
-{{ $prefab_files := site.Data.prefab_files }}
 
 {{ partial "data_table_search.html" . }}
 {{ .Content }}
@@ -20,13 +19,7 @@
         <tbody>
                 {{ range $name, $id := $prefab_data }}
                 <tr>
-                        <td>
-                                {{ if in $prefab_files $name }}
-                                <a href="{{ (printf "/prefabs/%s" $name) | relURL }}"><b>{{ $name }}</b></a>
-                                {{ else }}
-                                <b>{{ $name }}</b>
-                                {{ end }}
-                        </td>
+                        <td><a href="{{ (printf "/prefabs/%s" $name) | relURL }}"><b>{{ $name }}</b></a></td>
                         <td>{{ $id }}</td>
                 </tr>
                 {{ end }}

--- a/scripts/build_prefab_files.py
+++ b/scripts/build_prefab_files.py
@@ -1,21 +1,55 @@
 #!/usr/bin/env python3
-"""Generate data/prefab_files.yml listing prefab file names.
+"""Generate prefab content and data files from JSON input.
 
-This script enumerates all files under data/prefabs/ and writes a YAML
-list to data/prefab_files.yml. Each entry is the basename of a prefab
-file without its extension.
+This script reads the complete prefab list from ``data/prefabs/All.json``
+and ensures that a corresponding data file and content page exists for
+every prefab.  For each prefab name ``Foo`` with id ``123`` it writes:
+
+* ``data/prefabs/Foo.json`` containing ``{"Foo": 123}``
+* ``content/prefabs/Foo.md`` with front matter specifying ``title`` and
+  ``data_file`` so Hugo can render the page via
+  ``layouts/prefabs/single.html``.
+
+It also generates ``data/prefab_files.yml`` listing all prefab names.
+Existing files are left untouched.
 """
+
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
 
 def main() -> None:
     repo_root = Path(__file__).resolve().parents[1]
     prefab_dir = repo_root / "data" / "prefabs"
+    content_dir = repo_root / "content" / "prefabs"
     output_file = repo_root / "data" / "prefab_files.yml"
 
-    filenames = sorted(p.stem for p in prefab_dir.iterdir() if p.is_file())
-    content = "\n".join(f"- {name}" for name in filenames)
-    output_file.write_text(content + "\n")
+    all_file = prefab_dir / "All.json"
+    prefabs = json.loads(all_file.read_text())
+
+    names = sorted(prefabs.keys())
+    output_file.write_text("\n".join(f"- {name}" for name in names) + "\n")
+
+    content_dir.mkdir(parents=True, exist_ok=True)
+
+    for name in names:
+        prefab_id = prefabs[name]
+
+        data_path = prefab_dir / f"{name}.json"
+        if not data_path.exists():
+            data_path.write_text(json.dumps({name: prefab_id}, indent=2) + "\n")
+
+        content_path = content_dir / f"{name}.md"
+        if not content_path.exists():
+            front_matter = (
+                "---\n"
+                f"title: {name}\n"
+                f"data_file: {name}\n"
+                "---\n"
+            )
+            content_path.write_text(front_matter)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `build_prefab_files.py` to create individual prefab data and content files from `All.json`
- link prefab tables directly to generated pages

## Testing
- `pre-commit run --files scripts/build_prefab_files.py layouts/prefabs/single.html`


------
https://chatgpt.com/codex/tasks/task_e_689e3a7a92b0832d83b6e621d2425e50