### PR TITLE
Fix prefab permalink placeholder

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ ignoreLogs:
   - warning-goldmark-raw-html
 
 permalinks:
-  prefabs: "/prefabs/:contentbasename/"
+  prefabs: "/prefabs/:filename/"
 
 sitemap:
   changefreq: monthly


### PR DESCRIPTION
## Summary
- replace invalid :contentbasename in prefab permalinks with :filename

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_689e424063a4832d81d6a946c0fb57fd