### PR TITLE
Use relative URLs for local Hugo previews

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,6 @@
-baseURL: "https://mfoltz.github.io/"
+baseURL: "/"
+relativeURLs: true
+canonifyURLs: true
 title: "V Rising Mod Wiki"
 description: "Information about mods for the game V Rising: How to build, debug, and publish your mods."
 theme: "hugo-theme-relearn"


### PR DESCRIPTION
## Summary
- Use relative URLs and canonify URLs in config

## Testing
- `hugo server --port 1313`
- `curl -s http://localhost:1313/ | head -n 40`

------
https://chatgpt.com/codex/tasks/task_e_689e625e8abc832d9b14b2d1183866d3