### PR TITLE
feat: validate null bytes before root link rewrite

### DIFF
--- a/scripts/rewrite_root_links.py
+++ b/scripts/rewrite_root_links.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Rewrite root-relative Markdown links using relref shortcodes.
+
+This script scans ``content/prefabs`` for Markdown files and rewrites any
+links that start with ``/`` to use Hugo ``relref`` shortcodes instead. It
+also validates that no null bytes are present in the source text or the
+rewritten output.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT_LINK_RE = re.compile(r"\]\(/([^\s)]+)\)")
+
+
+def rewrite_links(text: str) -> str:
+    def _replace(match: re.Match[str]) -> str:
+        target = match.group(1)
+        path, sep, anchor = target.partition("#")
+        if not Path(path).suffix:
+            path = f"{path}.md"
+        anchor = f"#{anchor}" if anchor else ""
+        return f']({{< relref "{path}{anchor}" >}})'
+
+    return ROOT_LINK_RE.sub(_replace, text)
+
+
+def process_file(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    if "\x00" in text:
+        raise ValueError(f"{path} contains null bytes before rewrite")
+
+    new_text = rewrite_links(text)
+    if "\x00" in new_text:
+        raise ValueError(f"{path} contains null bytes after rewrite")
+
+    if new_text != text:
+        path.write_text(new_text, encoding="utf-8")
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    for md_path in (repo_root / "content" / "prefabs").glob("*.md"):
+        process_file(md_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add rewrite_root_links.py to rewrite root-relative links and validate null bytes

## Testing
- `python scripts/rewrite_root_links.py` *(fails: /workspace/mfoltz.github.io/content/prefabs/AB_Cursed_Witch_ExplodingMushrooms_Trigger.md contains null bytes before rewrite)*
- `grep -Pl '\x00' content/prefabs/*.md | wc -l`
- `timeout 100 scripts/check_shortcode_syntax.sh` *(times out)*
- `timeout 100 ./scripts/dev.sh build` *(times out)*

------
https://chatgpt.com/codex/tasks/task_e_689fe27865c4832db85529bb5b1ee4fb