### PR TITLE
docs: fix relref example

### DIFF
--- a/content/editing/_index.md
+++ b/content/editing/_index.md
@@ -30,7 +30,7 @@ You can just paste images while inside the GitHub markdown editor and it will up
 Use Hugo's `relref` shortcode to link between pages:
 
 ```md
-[link text]({{< relref "path/to/page.md" >}})
+[link text]({{%/* relref "path/to/page.md" */%}})
 ```
 
 Avoid root-relative links like `[text](/path/)`; `relref` keeps links working when pages move.


### PR DESCRIPTION
## Summary
- fix relref shortcode example in editing docs

## Testing
- `scripts/check_shortcode_syntax.sh content/editing/_index.md`
- `./scripts/dev.sh build`


------
https://chatgpt.com/codex/tasks/task_e_689ffacfb8bc832d9738b5ab55565e0a