### PR TITLE
Handle trailing slash links in rewrite_root_links

### DIFF
--- a/scripts/rewrite_root_links.py
+++ b/scripts/rewrite_root_links.py
@@ -5,6 +5,10 @@ This script scans ``content/prefabs`` for Markdown files and rewrites any
 links that start with ``/`` to use Hugo ``relref`` shortcodes instead. It
 also validates that no null bytes are present in the source text or the
 rewritten output.
+
+Links ending with ``/`` are rewritten to reference ``_index.md``. All other
+links without an explicit suffix are rewritten to ``.md``. Anchors specified
+with ``#anchor`` are preserved after the rewritten path.
 """
 
 from __future__ import annotations
@@ -18,8 +22,10 @@ ROOT_LINK_RE = re.compile(r"\]\(/([^\s)]+)\)")
 def rewrite_links(text: str) -> str:
     def _replace(match: re.Match[str]) -> str:
         target = match.group(1)
-        path, sep, anchor = target.partition("#")
-        if not Path(path).suffix:
+        path, _, anchor = target.partition("#")
+        if path.endswith("/"):
+            path = f"{path.rstrip('/')}/_index.md"
+        elif not Path(path).suffix:
             path = f"{path}.md"
         anchor = f"#{anchor}" if anchor else ""
         return f']({{< relref "{path}{anchor}" >}})'
@@ -42,7 +48,7 @@ def process_file(path: Path) -> None:
 
 def main() -> None:
     repo_root = Path(__file__).resolve().parents[1]
-    for md_path in (repo_root / "content" / "prefabs").glob("*.md"):
+    for md_path in (repo_root / "content" / "prefabs").rglob("*.md"):
         process_file(md_path)
 
 

--- a/tests/test_rewrite_root_links.py
+++ b/tests/test_rewrite_root_links.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+from rewrite_root_links import rewrite_links
+
+
+def test_rewrites_to_md():
+    src = "See [link](/foo/bar)"
+    expected = 'See [link]({< relref "foo/bar.md" >})'
+    assert rewrite_links(src) == expected
+
+
+def test_rewrites_to_md_and_preserves_anchor():
+    src = "See [link](/foo/bar#section)"
+    expected = 'See [link]({< relref "foo/bar.md#section" >})'
+    assert rewrite_links(src) == expected
+
+
+def test_rewrites_trailing_slash_to_index():
+    src = "See [dir](/foo/bar/)"
+    expected = 'See [dir]({< relref "foo/bar/_index.md" >})'
+    assert rewrite_links(src) == expected
+
+
+def test_rewrites_trailing_slash_to_index_and_preserves_anchor():
+    src = "See [dir](/foo/bar/#section)"
+    expected = 'See [dir]({< relref "foo/bar/_index.md#section" >})'
+    assert rewrite_links(src) == expected


### PR DESCRIPTION
## Summary
- recursively scan prefabs for markdown and rewrite root-relative links
- treat links ending in `/` as `_index.md` while preserving anchors
- add tests for `.md` and `_index.md` rewrite cases

## Testing
- `pytest tests/test_rewrite_root_links.py`
- `scripts/check_shortcode_syntax.sh tests/test_rewrite_root_links.py`
- `./scripts/dev.sh build` *(fails: hugo: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a004f5d970832d8e03f3d7e209af02