### PR TITLE
Use Hugo templating for prefab index and fix relref example

### DIFF
--- a/content/editing/_index.md
+++ b/content/editing/_index.md
@@ -30,7 +30,7 @@ You can just paste images while inside the GitHub markdown editor and it will up
 Use Hugo's `relref` shortcode to link between pages:
 
 ```md
-[link text]({{%/* relref "path/to/page.md" */%}})
+[link text]({{%/* relref "dev/_index.md" */%}})
 ```
 
 Avoid root-relative links like `[text](/path/)`; `relref` keeps links working when pages move.

--- a/content/prefabs/index.md
+++ b/content/prefabs/index.md
@@ -11,11 +11,9 @@ Prefabs are identifers often used in commands or configurations to refer to an o
 Full list here **(warning large file)**: [all prefabs](./All) also the remainder of the prefabs with fewer than 10 in a category into [remainders prefabs](./Remainders). [Vblood Prefabs by Name](./VBloodNames).
 
 <div class="prefab-list">
-  {% for prefab in site.data.prefabs %}
-    {% assign name = prefab[0] | replace: ".json", "" %}
-    {% if name == "All" %}{% continue %}{% endif %}
-    
-    <a class="prefab-item" href="{{ site.baseurl }}/prefabs/{{ name }}"><b>{{ name }}</b> ({{prefab[1].size}})</a>
-
-  {% endfor %}
+  {{ range $name, $prefab := .Site.Data.prefabs }}
+    {{ if ne $name "All" }}
+      <a class="prefab-item" href="{{ (printf "/prefabs/%s" $name) | relURL }}"><b>{{ $name }}</b> ({{ len $prefab }})</a>
+    {{ end }}
+  {{ end }}
 </div>


### PR DESCRIPTION
## Summary
- Replace Liquid loop in prefab index with Hugo template range and relURL
- Update editing guide's relref example to point to existing dev page

## Testing
- `scripts/check_shortcode_syntax.sh content/prefabs/index.md content/editing/_index.md`
- `./scripts/dev.sh build` *(fails: build did not complete within time; warnings about shortcodes remain)*

------
https://chatgpt.com/codex/tasks/task_e_68a016c22164832d847bd921709a7607