### PR TITLE
Convert relref in prefabs AB_Bandit_Foreman_Crossbow_Hard_BloodRage_AbilityGroup–AB_Bandit_Mugger_Block_AbilityGroup

### DIFF
--- a/content/prefabs/AB_Bandit_Foreman_Crossbow_Hard_BloodRage_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_Foreman_Crossbow_Hard_BloodRage_AbilityGroup.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `-1432555386`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,23 +85,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1432555386`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Foreman_Crossbow_Hard_Cast PrefabGuid(-1555191296)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 134`
@@ -237,7 +237,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -260,16 +260,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_Crossbow_Hard_BloodRage_Cast.md
+++ b/content/prefabs/AB_Bandit_Foreman_Crossbow_Hard_BloodRage_Cast.md
@@ -11,68 +11,68 @@ layout: default
 
 **GUID:** `-1188423561`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Foreman_Crossbow_Hard_BloodRage_Cast PrefabGuid(-1188423561)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 0.9`
   - `PostCastTime: 0.5`
   - `HideCastBar: True`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 0.5`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0.5`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -81,7 +81,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -90,24 +90,24 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0`
   - `Duration: 1.6`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 4.3`
   - `Max: 10`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -116,10 +116,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1188423561`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Foreman_Crossbow_Hard_Projectile PrefabGuid(-1461521784)`
@@ -130,11 +130,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 119`
@@ -282,7 +282,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -305,16 +305,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_Crossbow_Hard_Cast.md
+++ b/content/prefabs/AB_Bandit_Foreman_Crossbow_Hard_Cast.md
@@ -11,71 +11,71 @@ layout: default
 
 **GUID:** `-1555191296`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Foreman_Crossbow_Hard_Cast PrefabGuid(-1555191296)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 1.4`
   - `PostCastTime: 1`
   - `HideCastBar: True`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityAimPrediction](/components/AbilityAimPrediction)
+- [ProjectM.AbilityAimPrediction]({< relref "components/AbilityAimPrediction.md" >})
   - `AimPredictionFactor: 1.4`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 0.5`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 1`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -84,7 +84,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -93,24 +93,24 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0`
   - `Duration: 2.4`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 4.3`
   - `Max: 10`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -119,10 +119,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1555191296`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Foreman_Crossbow_Hard_Projectile PrefabGuid(-1461521784)`
@@ -133,11 +133,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 0`
@@ -285,7 +285,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -308,16 +308,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_RapidShot_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_Foreman_RapidShot_AbilityGroup.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `-1326540020`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,23 +85,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1326540020`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Foreman_RapidShot_Cast PrefabGuid(13962946)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 12`
@@ -237,7 +237,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -260,16 +260,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_RapidShot_Cast.md
+++ b/content/prefabs/AB_Bandit_Foreman_RapidShot_Cast.md
@@ -11,68 +11,68 @@ layout: default
 
 **GUID:** `13962946`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Foreman_RapidShot_Cast PrefabGuid(13962946)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 0.4`
   - `PostCastTime: 0.2`
   - `HideCastBar: True`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 0.5`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0.2`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -81,7 +81,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -90,24 +90,24 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0`
   - `Duration: 2.5`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 4.3`
   - `Max: 10`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -116,10 +116,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 13962946`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Foreman_RapidShot_Projectile PrefabGuid(1154919829)`
@@ -130,11 +130,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 194`
@@ -282,7 +282,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -305,16 +305,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_RapidShot_Hard_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_Foreman_RapidShot_Hard_AbilityGroup.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `-1696612225`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,23 +85,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1696612225`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Foreman_RapidShot_Hard_Cast PrefabGuid(45482985)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 127`
@@ -237,7 +237,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -260,16 +260,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_RapidShot_Hard_Cast.md
+++ b/content/prefabs/AB_Bandit_Foreman_RapidShot_Hard_Cast.md
@@ -11,68 +11,68 @@ layout: default
 
 **GUID:** `45482985`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Foreman_RapidShot_Hard_Cast PrefabGuid(45482985)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 0.25`
   - `PostCastTime: 0.2`
   - `HideCastBar: True`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 0.3`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0.2`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -81,7 +81,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -90,24 +90,24 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0`
   - `Duration: 2.5`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 4.3`
   - `Max: 10`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -116,10 +116,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 45482985`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Foreman_RapidShot_Projectile PrefabGuid(1154919829)`
@@ -130,11 +130,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 233`
@@ -282,7 +282,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -305,16 +305,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_RapidShot_Init_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_Foreman_RapidShot_Init_AbilityGroup.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `-871701576`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,23 +85,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -871701576`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Foreman_RapidShot_Init_Cast PrefabGuid(1428691280)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 184`
@@ -237,7 +237,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -260,16 +260,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_RapidShot_Init_Buff.md
+++ b/content/prefabs/AB_Bandit_Foreman_RapidShot_Init_Buff.md
@@ -11,20 +11,20 @@ layout: default
 
 **GUID:** `-1850501474`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.Buff](/components/Buff)
+- [ProjectM.Buff]({< relref "components/Buff.md" >})
   - `StartTimeUnmodified: 0`
   - `Target: Entity(0:0)`
   - `BuffType: ProjectM.BuffType Parallel`
@@ -36,32 +36,32 @@ layout: default
   - `OneInstancePerOwner: False`
   - `BuffEffectType: ProjectM.BuffEffectType Debuff`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.Age](/components/Age)
+- [ProjectM.Age]({< relref "components/Age.md" >})
   - `Value: 0`
 
-- [ProjectM.BuffCategory](/components/BuffCategory)
+- [ProjectM.BuffCategory]({< relref "components/BuffCategory.md" >})
   - `Level: 0`
   - `Groups: ProjectM.BuffCategoryFlag None`
   - `KeepOldest: False`
 
-- [ProjectM.LifeTime](/components/LifeTime)
+- [ProjectM.LifeTime]({< relref "components/LifeTime.md" >})
   - `Duration: 5`
   - `EndAction: ProjectM.LifeTimeEndAction Destroy`
 
-- [ProjectM.BuffModificationFlagData](/components/BuffModificationFlagData)
+- [ProjectM.BuffModificationFlagData]({< relref "components/BuffModificationFlagData.md" >})
   - `ModificationTypes: 16`
   - `ModificationId: Unset`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_ajchjhccfg`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,10 +85,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1850501474`
 
-- [ProjectM.CreateGameplayEventsOnDestroy](/components/CreateGameplayEventsOnDestroy)
+- [ProjectM.CreateGameplayEventsOnDestroy]({< relref "components/CreateGameplayEventsOnDestroy.md" >})
 
 - **[0]**
   - `EventId: Local - -1285857012`
@@ -96,7 +96,7 @@ layout: default
   - `SpecificDestroyReason: False`
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 158`
@@ -292,7 +292,7 @@ layout: default
 
 - **64 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -324,10 +324,10 @@ layout: default
 - **[9]**
   - `Value: -1`
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_RapidShot_Init_Cast.md
+++ b/content/prefabs/AB_Bandit_Foreman_RapidShot_Init_Cast.md
@@ -11,72 +11,72 @@ layout: default
 
 **GUID:** `1428691280`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Foreman_RapidShot_Init_Cast PrefabGuid(1428691280)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 80`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 3`
   - `PostCastTime: 0.2`
   - `HideCastBar: True`
 
-- [ProjectM.ChangeKnockbackResistanceDuringCast](/components/ChangeKnockbackResistanceDuringCast)
+- [ProjectM.ChangeKnockbackResistanceDuringCast]({< relref "components/ChangeKnockbackResistanceDuringCast.md" >})
   - `KnockbackResistanceIndex: 9`
   - `ModificationId: Unset`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 0.5`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0.3`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -85,7 +85,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -94,20 +94,20 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0`
   - `Duration: 4.5`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -116,10 +116,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1428691280`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Foreman_RapidShot_Init_Buff PrefabGuid(-1850501474)`
@@ -130,11 +130,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 80`
@@ -282,7 +282,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -305,16 +305,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_RapidShot_Init_Hard_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_Foreman_RapidShot_Init_Hard_AbilityGroup.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `-1568783706`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,23 +85,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1568783706`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Foreman_RapidShot_Init_Hard_Cast PrefabGuid(-1456665278)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 166`
@@ -237,7 +237,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -260,16 +260,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_RapidShot_Init_Hard_Cast.md
+++ b/content/prefabs/AB_Bandit_Foreman_RapidShot_Init_Hard_Cast.md
@@ -11,72 +11,72 @@ layout: default
 
 **GUID:** `-1456665278`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Foreman_RapidShot_Init_Hard_Cast PrefabGuid(-1456665278)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 80`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 2.4`
   - `PostCastTime: 0.2`
   - `HideCastBar: True`
 
-- [ProjectM.ChangeKnockbackResistanceDuringCast](/components/ChangeKnockbackResistanceDuringCast)
+- [ProjectM.ChangeKnockbackResistanceDuringCast]({< relref "components/ChangeKnockbackResistanceDuringCast.md" >})
   - `KnockbackResistanceIndex: 9`
   - `ModificationId: Unset`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 0.5`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0.3`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -85,7 +85,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -94,20 +94,20 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0`
   - `Duration: 4.5`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -116,10 +116,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1456665278`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Foreman_RapidShot_Init_Buff PrefabGuid(-1850501474)`
@@ -130,11 +130,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 66`
@@ -282,7 +282,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -305,16 +305,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_RapidShot_StaggerBuff.md
+++ b/content/prefabs/AB_Bandit_Foreman_RapidShot_StaggerBuff.md
@@ -11,20 +11,20 @@ layout: default
 
 **GUID:** `1772599073`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.Buff](/components/Buff)
+- [ProjectM.Buff]({< relref "components/Buff.md" >})
   - `StartTimeUnmodified: 0`
   - `Target: Entity(0:0)`
   - `BuffType: ProjectM.BuffType Replace`
@@ -36,38 +36,38 @@ layout: default
   - `OneInstancePerOwner: False`
   - `BuffEffectType: ProjectM.BuffEffectType Debuff`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.Age](/components/Age)
+- [ProjectM.Age]({< relref "components/Age.md" >})
   - `Value: 0`
 
-- [ProjectM.BuffCategory](/components/BuffCategory)
+- [ProjectM.BuffCategory]({< relref "components/BuffCategory.md" >})
   - `Level: 0`
   - `Groups: ProjectM.BuffCategoryFlag None`
   - `KeepOldest: False`
 
-- [ProjectM.DiminishingReturn](/components/DiminishingReturn)
+- [ProjectM.DiminishingReturn]({< relref "components/DiminishingReturn.md" >})
   - `DiminishingBuff: DiminishingReturn_Buff_Stun PrefabGuid(-160846617)`
   - `SCTPrefab: SCT_Type_Immune PrefabGuid(-1203333778)`
   - `AllowOnUnitTarget: False`
   - `AllowFromUnitOwner: False`
 
-- [ProjectM.LifeTime](/components/LifeTime)
+- [ProjectM.LifeTime]({< relref "components/LifeTime.md" >})
   - `Duration: 2`
   - `EndAction: ProjectM.LifeTimeEndAction Destroy`
 
-- [ProjectM.BuffModificationFlagData](/components/BuffModificationFlagData)
+- [ProjectM.BuffModificationFlagData]({< relref "components/BuffModificationFlagData.md" >})
   - `ModificationTypes: 1107296272`
   - `ModificationId: Unset`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -76,13 +76,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_ajchjhccfg`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -91,10 +91,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1772599073`
 
-- [ProjectM.DiminishingReturnElement](/components/DiminishingReturnElement)
+- [ProjectM.DiminishingReturnElement]({< relref "components/DiminishingReturnElement.md" >})
 
 - **[0]**
   - `DurationFactor: 0.67`
@@ -102,7 +102,7 @@ layout: default
 - **[1]**
   - `DurationFactor: 0.33`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 33`
@@ -298,7 +298,7 @@ layout: default
 
 - **64 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -330,10 +330,10 @@ layout: default
 - **[9]**
   - `Value: -1`
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_Reinforcement_Cast.md
+++ b/content/prefabs/AB_Bandit_Foreman_Reinforcement_Cast.md
@@ -11,68 +11,68 @@ layout: default
 
 **GUID:** `-968455089`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Foreman_Reinforcement_Cast PrefabGuid(-968455089)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 1.5`
   - `PostCastTime: 1`
   - `HideCastBar: True`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 20`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 1`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -81,7 +81,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -90,20 +90,20 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 1`
   - `InDuration: 0`
   - `Duration: 0.5`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [ProjectM.Network.MoveDuringCastData](/components/MoveDuringCastData)
+- [ProjectM.Network.MoveDuringCastData]({< relref "components/MoveDuringCastData.md" >})
   - `ManualDuration: 0`
   - `ForceMovementLength: 0`
   - `CurveX: ProjectM.CurveReference ProjectM.CurveReference`
@@ -120,21 +120,21 @@ layout: default
   - `IgnoreMovementImpair: False`
   - `IgnoreMovementSpeedChanges: False`
 
-- [Unity.Transforms.Rotation](/components/Rotation)
+- [Unity.Transforms.Rotation]({< relref "components/Rotation.md" >})
   - `Value: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.Translation](/components/Translation)
+- [Unity.Transforms.Translation]({< relref "components/Translation.md" >})
   - `Value: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
 
-- [Unity.Transforms.LocalToWorld](/components/LocalToWorld)
+- [Unity.Transforms.LocalToWorld]({< relref "components/LocalToWorld.md" >})
   - `Value: Unity.Mathematics.float4x4 float4x4(1f, 0f, 0f, 0f,  0f, 1f, 0f, 0f,  0f, 0f, 1f, 0f,  0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.LocalTransform](/components/LocalTransform)
+- [Unity.Transforms.LocalTransform]({< relref "components/LocalTransform.md" >})
   - `Position: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
   - `Scale: 1`
   - `Rotation: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -143,10 +143,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -968455089`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Foreman_Reinforcement_Summon PrefabGuid(891231141)`
@@ -157,11 +157,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 79`
@@ -309,7 +309,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -332,16 +332,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_Reinforcement_GateBoss_MinionBuff.md
+++ b/content/prefabs/AB_Bandit_Foreman_Reinforcement_GateBoss_MinionBuff.md
@@ -11,20 +11,20 @@ layout: default
 
 **GUID:** `1936552741`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.Buff](/components/Buff)
+- [ProjectM.Buff]({< relref "components/Buff.md" >})
   - `StartTimeUnmodified: 0`
   - `Target: Entity(0:0)`
   - `BuffType: ProjectM.BuffType Parallel`
@@ -36,24 +36,24 @@ layout: default
   - `OneInstancePerOwner: False`
   - `BuffEffectType: ProjectM.BuffEffectType Debuff`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.Age](/components/Age)
+- [ProjectM.Age]({< relref "components/Age.md" >})
   - `Value: 0`
 
-- [ProjectM.BuffCategory](/components/BuffCategory)
+- [ProjectM.BuffCategory]({< relref "components/BuffCategory.md" >})
   - `Level: 0`
   - `Groups: ProjectM.BuffCategoryFlag None`
   - `KeepOldest: False`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -62,13 +62,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_fkbkbchgb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -77,10 +77,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1936552741`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 37`
@@ -252,7 +252,7 @@ layout: default
 
 - **56 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -278,10 +278,10 @@ layout: default
 - **[7]**
   - `Value: -1`
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_Reinforcement_Group.md
+++ b/content/prefabs/AB_Bandit_Foreman_Reinforcement_Group.md
@@ -11,31 +11,31 @@ layout: default
 
 **GUID:** `1914101495`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -45,10 +45,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -57,7 +57,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -66,13 +66,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -81,23 +81,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1914101495`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Foreman_Reinforcement_Cast PrefabGuid(-968455089)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 247`
@@ -233,7 +233,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -256,16 +256,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_Roll_CastAndRoll.md
+++ b/content/prefabs/AB_Bandit_Foreman_Roll_CastAndRoll.md
@@ -11,82 +11,82 @@ layout: default
 
 **GUID:** `-902150618`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.HideWeapon](/components/HideWeapon)
+- [ProjectM.HideWeapon]({< relref "components/HideWeapon.md" >})
   - `HideWeaponSequenceGUID: SequenceGUID 1136240177`
   - `HideWeaponState: SequenceState`
   - `Id: Entity(0:0)`
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Foreman_Roll_CastAndRoll PrefabGuid(-902150618)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit_IgnoreInCombat`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityIgnoreSettings](/components/AbilityIgnoreSettings)
+- [ProjectM.AbilityIgnoreSettings]({< relref "components/AbilityIgnoreSettings.md" >})
   - `IgnorePostCast: True`
   - `IgnoreGlobalCooldown: True`
   - `IgnoreAbilityImpair: False`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 8`
   - `InterruptLowerPriority: True`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 0.5`
   - `PostCastTime: 0.2`
   - `HideCastBar: True`
 
-- [ProjectM.ChangeKnockbackResistanceDuringCast](/components/ChangeKnockbackResistanceDuringCast)
+- [ProjectM.ChangeKnockbackResistanceDuringCast]({< relref "components/ChangeKnockbackResistanceDuringCast.md" >})
   - `KnockbackResistanceIndex: 13`
   - `ModificationId: Unset`
 
-- [ProjectM.HideWeaponDuringCast](/components/HideWeaponDuringCast)
+- [ProjectM.HideWeaponDuringCast]({< relref "components/HideWeaponDuringCast.md" >})
   - `CastStartTime: 0`
   - `Duration: 1`
   - `CastStartCounter: 0`
   - `Type: ProjectM.HideWeaponDuringCastType CastAndPostCast`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 7`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -95,7 +95,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -104,20 +104,20 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0.4`
   - `InDuration: 0`
   - `Duration: 0.6`
   - `OutDuration: 0.7`
   - `UseCastDuration: False`
 
-- [ProjectM.Network.MoveDuringCastData](/components/MoveDuringCastData)
+- [ProjectM.Network.MoveDuringCastData]({< relref "components/MoveDuringCastData.md" >})
   - `ManualDuration: 0`
   - `ForceMovementLength: 7`
   - `CurveX: ProjectM.CurveReference ProjectM.CurveReference`
@@ -134,11 +134,11 @@ layout: default
   - `IgnoreMovementImpair: False`
   - `IgnoreMovementSpeedChanges: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 2`
   - `Max: 4`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -147,14 +147,14 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -902150618`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 38`
@@ -302,7 +302,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -325,16 +325,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_Roll_Group.md
+++ b/content/prefabs/AB_Bandit_Foreman_Roll_Group.md
@@ -11,41 +11,41 @@ layout: default
 
 **GUID:** `-1773431654`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityChargesState](/components/AbilityChargesState)
+- [ProjectM.AbilityChargesState]({< relref "components/AbilityChargesState.md" >})
   - `ChargeTime: 0`
   - `CurrentCharges: 3`
 
-- [ProjectM.AbilityChargesData](/components/AbilityChargesData)
+- [ProjectM.AbilityChargesData]({< relref "components/AbilityChargesData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `ChargeUpTime: 6`
   - `MaxCharges: 3`
   - `IgnoreCooldownModifier: False`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -55,10 +55,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -67,7 +67,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -76,13 +76,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_cjbjeehdbk`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -91,23 +91,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1773431654`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Foreman_Roll_CastAndRoll PrefabGuid(-902150618)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 154`
@@ -267,7 +267,7 @@ layout: default
 
 - **52 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -299,16 +299,16 @@ layout: default
 - **[9]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_ThrowNet_Buff.md
+++ b/content/prefabs/AB_Bandit_Foreman_ThrowNet_Buff.md
@@ -11,20 +11,20 @@ layout: default
 
 **GUID:** `-1388221055`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.Buff](/components/Buff)
+- [ProjectM.Buff]({< relref "components/Buff.md" >})
   - `StartTimeUnmodified: 0`
   - `Target: Entity(0:0)`
   - `BuffType: ProjectM.BuffType Replace`
@@ -36,32 +36,32 @@ layout: default
   - `OneInstancePerOwner: False`
   - `BuffEffectType: ProjectM.BuffEffectType Debuff`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.Age](/components/Age)
+- [ProjectM.Age]({< relref "components/Age.md" >})
   - `Value: 0`
 
-- [ProjectM.BuffCategory](/components/BuffCategory)
+- [ProjectM.BuffCategory]({< relref "components/BuffCategory.md" >})
   - `Level: 0`
   - `Groups: ProjectM.BuffCategoryFlag Slow`
   - `KeepOldest: False`
 
-- [ProjectM.LifeTime](/components/LifeTime)
+- [ProjectM.LifeTime]({< relref "components/LifeTime.md" >})
   - `Duration: 2`
   - `EndAction: ProjectM.LifeTimeEndAction Destroy`
 
-- [ProjectM.BuffModificationFlagData](/components/BuffModificationFlagData)
+- [ProjectM.BuffModificationFlagData]({< relref "components/BuffModificationFlagData.md" >})
   - `ModificationTypes: 16`
   - `ModificationId: Unset`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_ajchjhccfg`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,10 +85,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1388221055`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 129`
@@ -284,7 +284,7 @@ layout: default
 
 - **64 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -316,10 +316,10 @@ layout: default
 - **[9]**
   - `Value: -1`
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_ThrowNet_Cast.md
+++ b/content/prefabs/AB_Bandit_Foreman_ThrowNet_Cast.md
@@ -11,85 +11,85 @@ layout: default
 
 **GUID:** `-378355710`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.HideWeapon](/components/HideWeapon)
+- [ProjectM.HideWeapon]({< relref "components/HideWeapon.md" >})
   - `HideWeaponSequenceGUID: SequenceGUID 1136240177`
   - `HideWeaponState: SequenceState`
   - `Id: Entity(0:0)`
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Foreman_ThrowNet_Cast PrefabGuid(-378355710)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPositionInaccuracy](/components/AbilityPositionInaccuracy)
+- [ProjectM.AbilityPositionInaccuracy]({< relref "components/AbilityPositionInaccuracy.md" >})
   - `CurrentOffset: Unity.Mathematics.float2 float2(0f, 0f)`
   - `MinDistance: 0`
   - `MaxDistance: 2`
   - `OnlyOnMovingTargets: True`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 1`
   - `PostCastTime: 0.6`
   - `HideCastBar: True`
 
-- [ProjectM.HideWeaponDuringCast](/components/HideWeaponDuringCast)
+- [ProjectM.HideWeaponDuringCast]({< relref "components/HideWeaponDuringCast.md" >})
   - `CastStartTime: 0`
   - `Duration: 1`
   - `CastStartCounter: 0`
   - `Type: ProjectM.HideWeaponDuringCastType CastAndPostCast`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 9`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -98,7 +98,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -107,24 +107,24 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0.15`
   - `Duration: 1.7`
   - `OutDuration: 0.1`
   - `UseCastDuration: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 0`
   - `Max: 9`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -133,10 +133,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -378355710`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Foreman_ThrowNet_Throw PrefabGuid(1792504388)`
@@ -147,11 +147,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 2`
@@ -299,7 +299,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -322,16 +322,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_ThrowNet_Group.md
+++ b/content/prefabs/AB_Bandit_Foreman_ThrowNet_Group.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `2130985273`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,23 +85,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 2130985273`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Foreman_ThrowNet_Cast PrefabGuid(-378355710)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 57`
@@ -237,7 +237,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -260,16 +260,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_VBlood_Emote_Aggro_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_Foreman_VBlood_Emote_Aggro_AbilityGroup.md
@@ -11,31 +11,31 @@ layout: default
 
 **GUID:** `-1675488046`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -45,10 +45,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -57,7 +57,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -66,27 +66,27 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [Unity.Transforms.Rotation](/components/Rotation)
+- [Unity.Transforms.Rotation]({< relref "components/Rotation.md" >})
   - `Value: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.Translation](/components/Translation)
+- [Unity.Transforms.Translation]({< relref "components/Translation.md" >})
   - `Value: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
 
-- [Unity.Transforms.LocalToWorld](/components/LocalToWorld)
+- [Unity.Transforms.LocalToWorld]({< relref "components/LocalToWorld.md" >})
   - `Value: Unity.Mathematics.float4x4 float4x4(1f, 0f, 0f, 0f,  0f, 1f, 0f, 0f,  0f, 0f, 1f, 0f,  0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.LocalTransform](/components/LocalTransform)
+- [Unity.Transforms.LocalTransform]({< relref "components/LocalTransform.md" >})
   - `Position: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
   - `Scale: 1`
   - `Rotation: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -95,23 +95,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1675488046`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Foreman_VBlood_Emote_Aggro_Cast PrefabGuid(-1709807211)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 210`
@@ -247,7 +247,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -270,16 +270,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_VBlood_Emote_Aggro_Buff.md
+++ b/content/prefabs/AB_Bandit_Foreman_VBlood_Emote_Aggro_Buff.md
@@ -11,20 +11,20 @@ layout: default
 
 **GUID:** `1564776620`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.Buff](/components/Buff)
+- [ProjectM.Buff]({< relref "components/Buff.md" >})
   - `StartTimeUnmodified: 0`
   - `Target: Entity(0:0)`
   - `BuffType: ProjectM.BuffType Replace`
@@ -36,42 +36,42 @@ layout: default
   - `OneInstancePerOwner: False`
   - `BuffEffectType: ProjectM.BuffEffectType Buff`
 
-- [ProjectM.ModifyMovementSpeedBuff](/components/ModifyMovementSpeedBuff)
+- [ProjectM.ModifyMovementSpeedBuff]({< relref "components/ModifyMovementSpeedBuff.md" >})
   - `MoveSpeed: 1`
   - `Curve: ProjectM.CurveReference ProjectM.CurveReference`
   - `MultiplyAdd: True`
 
-- [ProjectM.ChangeKnockbackResistanceBuff](/components/ChangeKnockbackResistanceBuff)
+- [ProjectM.ChangeKnockbackResistanceBuff]({< relref "components/ChangeKnockbackResistanceBuff.md" >})
   - `KnockbackResistanceIndex: 13`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.Age](/components/Age)
+- [ProjectM.Age]({< relref "components/Age.md" >})
   - `Value: 0`
 
-- [ProjectM.LifeTime](/components/LifeTime)
+- [ProjectM.LifeTime]({< relref "components/LifeTime.md" >})
   - `Duration: 1.66666`
   - `EndAction: ProjectM.LifeTimeEndAction Destroy`
 
-- [ProjectM.LastTranslation](/components/LastTranslation)
+- [ProjectM.LastTranslation]({< relref "components/LastTranslation.md" >})
   - `Value: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
 
-- [ProjectM.Team](/components/Team)
+- [ProjectM.Team]({< relref "components/Team.md" >})
   - `Value: 1`
   - `FactionIndex: -1`
 
-- [ProjectM.BuffModificationFlagData](/components/BuffModificationFlagData)
+- [ProjectM.BuffModificationFlagData]({< relref "components/BuffModificationFlagData.md" >})
   - `ModificationTypes: 33554448`
   - `ModificationId: Unset`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -80,13 +80,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_cbggkebbfk`
 
-- [ProjectM.Network.ModifyRotation](/components/ModifyRotation)
+- [ProjectM.Network.ModifyRotation]({< relref "components/ModifyRotation.md" >})
   - `PreviousTargetDirection: Il2CppSystem.Nullable_Unboxed`1[UnityEngine.Vector3]`
   - `OffsetRotation: Il2CppSystem.Nullable_Unboxed`1[UnityEngine.Vector3]`
   - `ActiveTimeline: ProjectM.Network.MinMaxValue ProjectM.Network.MinMaxValue`
@@ -97,24 +97,24 @@ layout: default
   - `UseZeroAsDefaultForCurveRotation: False`
   - `SnapToDirection: True`
 
-- [Unity.Transforms.Rotation](/components/Rotation)
+- [Unity.Transforms.Rotation]({< relref "components/Rotation.md" >})
   - `Value: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.Translation](/components/Translation)
+- [Unity.Transforms.Translation]({< relref "components/Translation.md" >})
   - `Value: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
 
-- [Unity.Transforms.LocalToWorld](/components/LocalToWorld)
+- [Unity.Transforms.LocalToWorld]({< relref "components/LocalToWorld.md" >})
   - `Value: Unity.Mathematics.float4x4 float4x4(1f, 0f, 0f, 0f,  0f, 1f, 0f, 0f,  0f, 0f, 1f, 0f,  0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.LocalTransform](/components/LocalTransform)
+- [Unity.Transforms.LocalTransform]({< relref "components/LocalTransform.md" >})
   - `Position: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
   - `Scale: 1`
   - `Rotation: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [ProjectM.TeamReference](/components/TeamReference)
+- [ProjectM.TeamReference]({< relref "components/TeamReference.md" >})
   - `Value: ModifiableEntity(0:0)`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -123,10 +123,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1564776620`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 172`
@@ -346,7 +346,7 @@ layout: default
 
 - **72 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -387,12 +387,12 @@ layout: default
 - **[12]**
   - `Value: -1`
 
-- [ProjectM.GetOwnerTeamOnSpawn](/components/GetOwnerTeamOnSpawn)
+- [ProjectM.GetOwnerTeamOnSpawn]({< relref "components/GetOwnerTeamOnSpawn.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Foreman_VBlood_Emote_Aggro_Cast.md
+++ b/content/prefabs/AB_Bandit_Foreman_VBlood_Emote_Aggro_Cast.md
@@ -11,78 +11,78 @@ layout: default
 
 **GUID:** `-1709807211`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.HideWeapon](/components/HideWeapon)
+- [ProjectM.HideWeapon]({< relref "components/HideWeapon.md" >})
   - `HideWeaponSequenceGUID: SequenceGUID 1136240177`
   - `HideWeaponState: SequenceState`
   - `Id: Entity(0:0)`
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Foreman_VBlood_Emote_Aggro_Cast PrefabGuid(-1709807211)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityIgnoreSettings](/components/AbilityIgnoreSettings)
+- [ProjectM.AbilityIgnoreSettings]({< relref "components/AbilityIgnoreSettings.md" >})
   - `IgnorePostCast: False`
   - `IgnoreGlobalCooldown: False`
   - `IgnoreAbilityImpair: False`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 0.1`
   - `PostCastTime: 0.1`
   - `HideCastBar: True`
 
-- [ProjectM.HideWeaponDuringCast](/components/HideWeaponDuringCast)
+- [ProjectM.HideWeaponDuringCast]({< relref "components/HideWeaponDuringCast.md" >})
   - `CastStartTime: 0`
   - `Duration: 1`
   - `CastStartCounter: 0`
   - `Type: ProjectM.HideWeaponDuringCastType CastAndPostCast`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 1`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -91,7 +91,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -100,34 +100,34 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0`
   - `Duration: 0`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [Unity.Transforms.Rotation](/components/Rotation)
+- [Unity.Transforms.Rotation]({< relref "components/Rotation.md" >})
   - `Value: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.Translation](/components/Translation)
+- [Unity.Transforms.Translation]({< relref "components/Translation.md" >})
   - `Value: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
 
-- [Unity.Transforms.LocalToWorld](/components/LocalToWorld)
+- [Unity.Transforms.LocalToWorld]({< relref "components/LocalToWorld.md" >})
   - `Value: Unity.Mathematics.float4x4 float4x4(1f, 0f, 0f, 0f,  0f, 1f, 0f, 0f,  0f, 0f, 1f, 0f,  0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.LocalTransform](/components/LocalTransform)
+- [Unity.Transforms.LocalTransform]({< relref "components/LocalTransform.md" >})
   - `Position: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
   - `Scale: 1`
   - `Rotation: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -136,10 +136,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1709807211`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Foreman_VBlood_Emote_Aggro_Buff PrefabGuid(1564776620)`
@@ -150,11 +150,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 149`
@@ -302,7 +302,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -325,18 +325,18 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.IgnoreInCombatBuff](/components/IgnoreInCombatBuff)
+- [ProjectM.IgnoreInCombatBuff]({< relref "components/IgnoreInCombatBuff.md" >})
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrostArrow_Camouflage_HARD_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_FrostArrow_Camouflage_HARD_AbilityGroup.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `1015070299`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,23 +85,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1015070299`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_FrostArrow_Camouflage_HARD_Cast PrefabGuid(1320706811)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 91`
@@ -237,7 +237,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -260,16 +260,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrostArrow_Camouflage_HARD_Cast.md
+++ b/content/prefabs/AB_Bandit_FrostArrow_Camouflage_HARD_Cast.md
@@ -11,62 +11,62 @@ layout: default
 
 **GUID:** `1320706811`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_FrostArrow_Camouflage_HARD_Cast PrefabGuid(1320706811)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 80`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 0.1`
   - `PostCastTime: 0.2`
   - `HideCastBar: True`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 15`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -75,7 +75,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -84,13 +84,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -99,10 +99,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1320706811`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_FrostArrow_Camouflage_HARD_Buff PrefabGuid(172001911)`
@@ -113,11 +113,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 251`
@@ -265,7 +265,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -288,16 +288,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrostArrow_Camouflage_HARD_EndBuff.md
+++ b/content/prefabs/AB_Bandit_FrostArrow_Camouflage_HARD_EndBuff.md
@@ -11,20 +11,20 @@ layout: default
 
 **GUID:** `-289232633`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.Buff](/components/Buff)
+- [ProjectM.Buff]({< relref "components/Buff.md" >})
   - `StartTimeUnmodified: 0`
   - `Target: Entity(0:0)`
   - `BuffType: ProjectM.BuffType Replace`
@@ -36,32 +36,32 @@ layout: default
   - `OneInstancePerOwner: False`
   - `BuffEffectType: ProjectM.BuffEffectType Buff`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.Age](/components/Age)
+- [ProjectM.Age]({< relref "components/Age.md" >})
   - `Value: 0`
 
-- [ProjectM.BuffCategory](/components/BuffCategory)
+- [ProjectM.BuffCategory]({< relref "components/BuffCategory.md" >})
   - `Level: 0`
   - `Groups: ProjectM.BuffCategoryFlag None`
   - `KeepOldest: False`
 
-- [ProjectM.LifeTime](/components/LifeTime)
+- [ProjectM.LifeTime]({< relref "components/LifeTime.md" >})
   - `Duration: 1`
   - `EndAction: ProjectM.LifeTimeEndAction Destroy`
 
-- [ProjectM.BuffModificationFlagData](/components/BuffModificationFlagData)
+- [ProjectM.BuffModificationFlagData]({< relref "components/BuffModificationFlagData.md" >})
   - `ModificationTypes: 1107296272`
   - `ModificationId: Unset`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_ajchjhccfg`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,10 +85,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -289232633`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 7`
@@ -284,7 +284,7 @@ layout: default
 
 - **64 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -316,10 +316,10 @@ layout: default
 - **[9]**
   - `Value: -1`
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_AbilityGroup.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `766284586`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,17 +70,17 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Shared.DamageReductionPerTarget](/components/DamageReductionPerTarget)
+- [ProjectM.Shared.DamageReductionPerTarget]({< relref "components/DamageReductionPerTarget.md" >})
   - `HitResetTimer: 1`
   - `ReductionModifier: 0.15`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -89,25 +89,25 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 766284586`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Shared.DamageReductionPerTargetElement](/components/DamageReductionPerTargetElement)
+- [ProjectM.Shared.DamageReductionPerTargetElement]({< relref "components/DamageReductionPerTargetElement.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_FrostArrow_RainOfArrows_Cast PrefabGuid(-652657527)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 42`
@@ -243,7 +243,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -266,16 +266,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_Cast.md
+++ b/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_Cast.md
@@ -11,68 +11,68 @@ layout: default
 
 **GUID:** `-652657527`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_FrostArrow_RainOfArrows_Cast PrefabGuid(-652657527)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 1.5`
   - `PostCastTime: 0.7`
   - `HideCastBar: True`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 1`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -81,7 +81,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -90,24 +90,24 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0`
   - `Duration: 2.5`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 1`
   - `Max: 1`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -116,10 +116,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -652657527`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_FrostArrow_RainOfArrows_Trigger PrefabGuid(1085881602)`
@@ -130,11 +130,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 137`
@@ -282,7 +282,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -305,16 +305,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_Hard_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_Hard_AbilityGroup.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `-328617085`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,17 +70,17 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Shared.DamageReductionPerTarget](/components/DamageReductionPerTarget)
+- [ProjectM.Shared.DamageReductionPerTarget]({< relref "components/DamageReductionPerTarget.md" >})
   - `HitResetTimer: 1`
   - `ReductionModifier: 0.15`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -89,25 +89,25 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -328617085`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Shared.DamageReductionPerTargetElement](/components/DamageReductionPerTargetElement)
+- [ProjectM.Shared.DamageReductionPerTargetElement]({< relref "components/DamageReductionPerTargetElement.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_FrostArrow_RainOfArrows_Hard_Cast PrefabGuid(2055017810)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 131`
@@ -243,7 +243,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -266,16 +266,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_Hard_Cast.md
+++ b/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_Hard_Cast.md
@@ -11,68 +11,68 @@ layout: default
 
 **GUID:** `2055017810`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_FrostArrow_RainOfArrows_Hard_Cast PrefabGuid(2055017810)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 1.5`
   - `PostCastTime: 0.7`
   - `HideCastBar: True`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 1`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -81,7 +81,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -90,24 +90,24 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0`
   - `Duration: 2.2`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 1`
   - `Max: 1`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -116,10 +116,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 2055017810`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_FrostArrow_RainOfArrows_Hard_Trigger01 PrefabGuid(-721181968)`
@@ -130,11 +130,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 82`
@@ -282,7 +282,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -305,16 +305,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_Hard_Trigger01.md
+++ b/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_Hard_Trigger01.md
@@ -11,53 +11,53 @@ layout: default
 
 **GUID:** `-721181968`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.GetOwnerRotation](/components/GetOwnerRotation)
+- [ProjectM.GetOwnerRotation]({< relref "components/GetOwnerRotation.md" >})
   - `OffsetDegreesClockwise: 0`
   - `Type: ProjectM.GetRotationType Rotation`
   - `RotationSource: ProjectM.GetOwnerRotationComponent+GetRotationSource Owner`
   - `InverseRotation: False`
 
-- [ProjectM.GetTranslationOnSpawn](/components/GetTranslationOnSpawn)
+- [ProjectM.GetTranslationOnSpawn]({< relref "components/GetTranslationOnSpawn.md" >})
   - `TranslationSource: ProjectM.GetTranslationSource Owner`
   - `SnapToGround: False`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.Age](/components/Age)
+- [ProjectM.Age]({< relref "components/Age.md" >})
   - `Value: 0`
 
-- [ProjectM.LifeTime](/components/LifeTime)
+- [ProjectM.LifeTime]({< relref "components/LifeTime.md" >})
   - `Duration: 0.3`
   - `EndAction: ProjectM.LifeTimeEndAction Destroy`
 
-- [ProjectM.ManualFirstFrameLastTranslation](/components/ManualFirstFrameLastTranslation)
+- [ProjectM.ManualFirstFrameLastTranslation]({< relref "components/ManualFirstFrameLastTranslation.md" >})
   - `Value: Il2CppSystem.Nullable_Unboxed`1[Unity.Mathematics.float3]`
 
-- [ProjectM.Team](/components/Team)
+- [ProjectM.Team]({< relref "components/Team.md" >})
   - `Value: 1`
   - `FactionIndex: -1`
 
-- [ProjectM.Scripting.ScriptDestroy](/components/ScriptDestroy)
+- [ProjectM.Scripting.ScriptDestroy]({< relref "components/ScriptDestroy.md" >})
   - `Handled: False`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -66,19 +66,19 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_kiighbfgg`
 
-- [Unity.Transforms.Rotation](/components/Rotation)
+- [Unity.Transforms.Rotation]({< relref "components/Rotation.md" >})
   - `Value: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.Translation](/components/Translation)
+- [Unity.Transforms.Translation]({< relref "components/Translation.md" >})
   - `Value: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
 
-- [ProjectM.Gameplay.Scripting.EvenSpreadCluster_DataServer](/components/EvenSpreadCluster_DataServer)
+- [ProjectM.Gameplay.Scripting.EvenSpreadCluster_DataServer]({< relref "components/EvenSpreadCluster_DataServer.md" >})
   - `OffsetAngle: 0.17453292`
   - `RandomAngle: 0.34906584`
   - `NewThrowEntity: AB_Bandit_FrostArrow_RainOfArrows_Hard_Throw01 PrefabGuid(-698051948)`
@@ -92,18 +92,18 @@ layout: default
   - `UseGameplayEventTargetPosition: False`
   - `TryFindThrowLocationIterations: 1`
 
-- [Unity.Transforms.LocalToWorld](/components/LocalToWorld)
+- [Unity.Transforms.LocalToWorld]({< relref "components/LocalToWorld.md" >})
   - `Value: Unity.Mathematics.float4x4 float4x4(1f, 0f, 0f, 0f,  0f, 1f, 0f, 0f,  0f, 0f, 1f, 0f,  0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.LocalTransform](/components/LocalTransform)
+- [Unity.Transforms.LocalTransform]({< relref "components/LocalTransform.md" >})
   - `Position: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
   - `Scale: 1`
   - `Rotation: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [ProjectM.TeamReference](/components/TeamReference)
+- [ProjectM.TeamReference]({< relref "components/TeamReference.md" >})
   - `Value: ModifiableEntity(0:0)`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -112,10 +112,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -721181968`
 
-- [ProjectM.CreateGameplayEventsOnDestroy](/components/CreateGameplayEventsOnDestroy)
+- [ProjectM.CreateGameplayEventsOnDestroy]({< relref "components/CreateGameplayEventsOnDestroy.md" >})
 
 - **[0]**
   - `EventId: Local - -136930912`
@@ -123,7 +123,7 @@ layout: default
   - `SpecificDestroyReason: False`
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.GameplayEventIdMapping](/components/GameplayEventIdMapping)
+- [ProjectM.GameplayEventIdMapping]({< relref "components/GameplayEventIdMapping.md" >})
 
 - **[0]**
   - `NextTriggerTime: 0`
@@ -133,7 +133,7 @@ layout: default
   - `CurrentTriggers: 0`
   - `TriggerMultipleTimes: False`
 
-- [ProjectM.SpawnPrefabOnGameplayEvent](/components/SpawnPrefabOnGameplayEvent)
+- [ProjectM.SpawnPrefabOnGameplayEvent]({< relref "components/SpawnPrefabOnGameplayEvent.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_FrostArrow_RainOfArrows_Hard_Trigger02 PrefabGuid(1789626324)`
@@ -142,7 +142,7 @@ layout: default
   - `Owner: ProjectM.SpawnPrefabOnGameplayEventOwner Inherit`
   - `Creator: ProjectM.SpawnPrefabOnGameplayEventCreator Inherit`
 
-- [ProjectM.GameplayEventListeners](/components/GameplayEventListeners)
+- [ProjectM.GameplayEventListeners]({< relref "components/GameplayEventListeners.md" >})
 
 - **[0]**
   - `EventIdIndex: 0`
@@ -151,7 +151,7 @@ layout: default
   - `GameplayEventType: ProjectM.GameplayEventTypeEnum SpawnPrefab`
   - `GameplayEventId: Local - -136930912`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 240`
@@ -225,7 +225,7 @@ layout: default
 - **[23]**
   - `Value: 0`
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -242,22 +242,22 @@ layout: default
 - **[4]**
   - `Value: -1`
 
-- [ProjectM.GetOwnerRotationOnlyOnSpawnTag](/components/GetOwnerRotationOnlyOnSpawnTag)
+- [ProjectM.GetOwnerRotationOnlyOnSpawnTag]({< relref "components/GetOwnerRotationOnlyOnSpawnTag.md" >})
 
-- [ProjectM.GetOwnerTeamOnSpawn](/components/GetOwnerTeamOnSpawn)
+- [ProjectM.GetOwnerTeamOnSpawn]({< relref "components/GetOwnerTeamOnSpawn.md" >})
 
 - **ProjectM.RunScriptOnGameplayEvents isn't handled**
 
-- [ProjectM.DisableWhenNoPlayersInRange](/components/DisableWhenNoPlayersInRange)
+- [ProjectM.DisableWhenNoPlayersInRange]({< relref "components/DisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Scripting.ScriptSpawn](/components/ScriptSpawn)
+- [ProjectM.Scripting.ScriptSpawn]({< relref "components/ScriptSpawn.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_Hard_Trigger02.md
+++ b/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_Hard_Trigger02.md
@@ -11,53 +11,53 @@ layout: default
 
 **GUID:** `1789626324`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.GetOwnerRotation](/components/GetOwnerRotation)
+- [ProjectM.GetOwnerRotation]({< relref "components/GetOwnerRotation.md" >})
   - `OffsetDegreesClockwise: 0`
   - `Type: ProjectM.GetRotationType Rotation`
   - `RotationSource: ProjectM.GetOwnerRotationComponent+GetRotationSource Owner`
   - `InverseRotation: False`
 
-- [ProjectM.GetTranslationOnSpawn](/components/GetTranslationOnSpawn)
+- [ProjectM.GetTranslationOnSpawn]({< relref "components/GetTranslationOnSpawn.md" >})
   - `TranslationSource: ProjectM.GetTranslationSource Owner`
   - `SnapToGround: False`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.Age](/components/Age)
+- [ProjectM.Age]({< relref "components/Age.md" >})
   - `Value: 0`
 
-- [ProjectM.LifeTime](/components/LifeTime)
+- [ProjectM.LifeTime]({< relref "components/LifeTime.md" >})
   - `Duration: 0.3`
   - `EndAction: ProjectM.LifeTimeEndAction Destroy`
 
-- [ProjectM.ManualFirstFrameLastTranslation](/components/ManualFirstFrameLastTranslation)
+- [ProjectM.ManualFirstFrameLastTranslation]({< relref "components/ManualFirstFrameLastTranslation.md" >})
   - `Value: Il2CppSystem.Nullable_Unboxed`1[Unity.Mathematics.float3]`
 
-- [ProjectM.Team](/components/Team)
+- [ProjectM.Team]({< relref "components/Team.md" >})
   - `Value: 1`
   - `FactionIndex: -1`
 
-- [ProjectM.Scripting.ScriptDestroy](/components/ScriptDestroy)
+- [ProjectM.Scripting.ScriptDestroy]({< relref "components/ScriptDestroy.md" >})
   - `Handled: False`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -66,19 +66,19 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_kiighbfgg`
 
-- [Unity.Transforms.Rotation](/components/Rotation)
+- [Unity.Transforms.Rotation]({< relref "components/Rotation.md" >})
   - `Value: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.Translation](/components/Translation)
+- [Unity.Transforms.Translation]({< relref "components/Translation.md" >})
   - `Value: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
 
-- [ProjectM.Gameplay.Scripting.EvenSpreadCluster_DataServer](/components/EvenSpreadCluster_DataServer)
+- [ProjectM.Gameplay.Scripting.EvenSpreadCluster_DataServer]({< relref "components/EvenSpreadCluster_DataServer.md" >})
   - `OffsetAngle: 0.17453292`
   - `RandomAngle: 0.34906584`
   - `NewThrowEntity: AB_Bandit_FrostArrow_RainOfArrows_Hard_Throw02 PrefabGuid(209868589)`
@@ -92,18 +92,18 @@ layout: default
   - `UseGameplayEventTargetPosition: False`
   - `TryFindThrowLocationIterations: 1`
 
-- [Unity.Transforms.LocalToWorld](/components/LocalToWorld)
+- [Unity.Transforms.LocalToWorld]({< relref "components/LocalToWorld.md" >})
   - `Value: Unity.Mathematics.float4x4 float4x4(1f, 0f, 0f, 0f,  0f, 1f, 0f, 0f,  0f, 0f, 1f, 0f,  0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.LocalTransform](/components/LocalTransform)
+- [Unity.Transforms.LocalTransform]({< relref "components/LocalTransform.md" >})
   - `Position: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
   - `Scale: 1`
   - `Rotation: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [ProjectM.TeamReference](/components/TeamReference)
+- [ProjectM.TeamReference]({< relref "components/TeamReference.md" >})
   - `Value: ModifiableEntity(0:0)`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -112,10 +112,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1789626324`
 
-- [ProjectM.CreateGameplayEventsOnDestroy](/components/CreateGameplayEventsOnDestroy)
+- [ProjectM.CreateGameplayEventsOnDestroy]({< relref "components/CreateGameplayEventsOnDestroy.md" >})
 
 - **[0]**
   - `EventId: Local - -136930912`
@@ -123,7 +123,7 @@ layout: default
   - `SpecificDestroyReason: False`
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 212`
@@ -197,7 +197,7 @@ layout: default
 - **[23]**
   - `Value: 0`
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -214,20 +214,20 @@ layout: default
 - **[4]**
   - `Value: -1`
 
-- [ProjectM.GetOwnerRotationOnlyOnSpawnTag](/components/GetOwnerRotationOnlyOnSpawnTag)
+- [ProjectM.GetOwnerRotationOnlyOnSpawnTag]({< relref "components/GetOwnerRotationOnlyOnSpawnTag.md" >})
 
-- [ProjectM.GetOwnerTeamOnSpawn](/components/GetOwnerTeamOnSpawn)
+- [ProjectM.GetOwnerTeamOnSpawn]({< relref "components/GetOwnerTeamOnSpawn.md" >})
 
 - **ProjectM.RunScriptOnGameplayEvents isn't handled**
 
-- [ProjectM.DisableWhenNoPlayersInRange](/components/DisableWhenNoPlayersInRange)
+- [ProjectM.DisableWhenNoPlayersInRange]({< relref "components/DisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Scripting.ScriptSpawn](/components/ScriptSpawn)
+- [ProjectM.Scripting.ScriptSpawn]({< relref "components/ScriptSpawn.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_Trigger.md
+++ b/content/prefabs/AB_Bandit_FrostArrow_RainOfArrows_Trigger.md
@@ -11,57 +11,57 @@ layout: default
 
 **GUID:** `1085881602`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.GetOwnerRotation](/components/GetOwnerRotation)
+- [ProjectM.GetOwnerRotation]({< relref "components/GetOwnerRotation.md" >})
   - `OffsetDegreesClockwise: 0`
   - `Type: ProjectM.GetRotationType Rotation`
   - `RotationSource: ProjectM.GetOwnerRotationComponent+GetRotationSource Owner`
   - `InverseRotation: False`
 
-- [ProjectM.GetTranslationOnSpawn](/components/GetTranslationOnSpawn)
+- [ProjectM.GetTranslationOnSpawn]({< relref "components/GetTranslationOnSpawn.md" >})
   - `TranslationSource: ProjectM.GetTranslationSource Owner`
   - `SnapToGround: False`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.Age](/components/Age)
+- [ProjectM.Age]({< relref "components/Age.md" >})
   - `Value: 0`
 
-- [ProjectM.LifeTime](/components/LifeTime)
+- [ProjectM.LifeTime]({< relref "components/LifeTime.md" >})
   - `Duration: 5`
   - `EndAction: ProjectM.LifeTimeEndAction Destroy`
 
-- [ProjectM.ManualFirstFrameLastTranslation](/components/ManualFirstFrameLastTranslation)
+- [ProjectM.ManualFirstFrameLastTranslation]({< relref "components/ManualFirstFrameLastTranslation.md" >})
   - `Value: Il2CppSystem.Nullable_Unboxed`1[Unity.Mathematics.float3]`
 
-- [ProjectM.Team](/components/Team)
+- [ProjectM.Team]({< relref "components/Team.md" >})
   - `Value: 1`
   - `FactionIndex: -1`
 
-- [ProjectM.Scripting.ScriptDestroy](/components/ScriptDestroy)
+- [ProjectM.Scripting.ScriptDestroy]({< relref "components/ScriptDestroy.md" >})
   - `Handled: False`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.NetworkedSettings](/components/NetworkedSettings)
+- [ProjectM.Network.NetworkedSettings]({< relref "components/NetworkedSettings.md" >})
   - `BasePriority: 2.1`
   - `SyncRate: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,19 +70,19 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_kiighbfgg`
 
-- [Unity.Transforms.Rotation](/components/Rotation)
+- [Unity.Transforms.Rotation]({< relref "components/Rotation.md" >})
   - `Value: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.Translation](/components/Translation)
+- [Unity.Transforms.Translation]({< relref "components/Translation.md" >})
   - `Value: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
 
-- [ProjectM.Gameplay.Scripting.EvenSpreadCluster_DataServer](/components/EvenSpreadCluster_DataServer)
+- [ProjectM.Gameplay.Scripting.EvenSpreadCluster_DataServer]({< relref "components/EvenSpreadCluster_DataServer.md" >})
   - `OffsetAngle: 0.17453292`
   - `RandomAngle: 0.34906584`
   - `NewThrowEntity: AB_Bandit_FrostArrow_RainOfArrows_Throw PrefabGuid(-1404569475)`
@@ -96,18 +96,18 @@ layout: default
   - `UseGameplayEventTargetPosition: False`
   - `TryFindThrowLocationIterations: 1`
 
-- [Unity.Transforms.LocalToWorld](/components/LocalToWorld)
+- [Unity.Transforms.LocalToWorld]({< relref "components/LocalToWorld.md" >})
   - `Value: Unity.Mathematics.float4x4 float4x4(1f, 0f, 0f, 0f,  0f, 1f, 0f, 0f,  0f, 0f, 1f, 0f,  0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.LocalTransform](/components/LocalTransform)
+- [Unity.Transforms.LocalTransform]({< relref "components/LocalTransform.md" >})
   - `Position: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
   - `Scale: 1`
   - `Rotation: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [ProjectM.TeamReference](/components/TeamReference)
+- [ProjectM.TeamReference]({< relref "components/TeamReference.md" >})
   - `Value: ModifiableEntity(0:0)`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -116,10 +116,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1085881602`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 2`
@@ -193,7 +193,7 @@ layout: default
 - **[23]**
   - `Value: 0`
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -210,22 +210,22 @@ layout: default
 - **[4]**
   - `Value: -1`
 
-- [ProjectM.DestroyOnSpawn](/components/DestroyOnSpawn)
+- [ProjectM.DestroyOnSpawn]({< relref "components/DestroyOnSpawn.md" >})
 
-- [ProjectM.GetOwnerRotationOnlyOnSpawnTag](/components/GetOwnerRotationOnlyOnSpawnTag)
+- [ProjectM.GetOwnerRotationOnlyOnSpawnTag]({< relref "components/GetOwnerRotationOnlyOnSpawnTag.md" >})
 
-- [ProjectM.GetOwnerTeamOnSpawn](/components/GetOwnerTeamOnSpawn)
+- [ProjectM.GetOwnerTeamOnSpawn]({< relref "components/GetOwnerTeamOnSpawn.md" >})
 
 - **ProjectM.RunScriptOnGameplayEvents isn't handled**
 
-- [ProjectM.DisableWhenNoPlayersInRange](/components/DisableWhenNoPlayersInRange)
+- [ProjectM.DisableWhenNoPlayersInRange]({< relref "components/DisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Scripting.ScriptSpawn](/components/ScriptSpawn)
+- [ProjectM.Scripting.ScriptSpawn]({< relref "components/ScriptSpawn.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrosttArrow_MultiShot_Cast.md
+++ b/content/prefabs/AB_Bandit_FrosttArrow_MultiShot_Cast.md
@@ -11,73 +11,73 @@ layout: default
 
 **GUID:** `-895811403`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_FrosttArrow_MultiShot_Cast PrefabGuid(-895811403)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityDirectionInaccuracy](/components/AbilityDirectionInaccuracy)
+- [ProjectM.AbilityDirectionInaccuracy]({< relref "components/AbilityDirectionInaccuracy.md" >})
   - `MaxDegrees: 3`
   - `CurrentDegrees: 0`
   - `OnlyOnMovingTargets: True`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 2.3`
   - `PostCastTime: 1`
   - `HideCastBar: True`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 4.5`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -86,7 +86,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -95,24 +95,24 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0.1`
   - `Duration: 3.1`
   - `OutDuration: 0.1`
   - `UseCastDuration: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 0`
   - `Max: 17`
 
-- [ProjectM.Shared.SpellModSetComponent](/components/SpellModSetComponent)
+- [ProjectM.Shared.SpellModSetComponent]({< relref "components/SpellModSetComponent.md" >})
   - `SpellMods: SpellModSet`
   - `SyncId: 0`
   - `Mod0: SpellMod`
@@ -141,14 +141,14 @@ layout: default
   - `Power: 0`
   - `Count: 0`
 
-- [ProjectM.Gameplay.Scripting.Script_MultiShot_Cast_DataServer](/components/Script_MultiShot_Cast_DataServer)
+- [ProjectM.Gameplay.Scripting.Script_MultiShot_Cast_DataServer]({< relref "components/Script_MultiShot_Cast_DataServer.md" >})
   - `Angle: 0.43633232`
   - `OffsetAllAngles: 0`
   - `NewProjectile: AB_Bandit_FrosttArrow_MultiShot_Projectile PrefabGuid(1042909452)`
   - `Count: 3`
   - `Condition: None`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -157,14 +157,14 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -895811403`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 181`
@@ -312,7 +312,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -335,18 +335,18 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.RunScriptOnPreCastEnded](/components/RunScriptOnPreCastEnded)
+- [ProjectM.RunScriptOnPreCastEnded]({< relref "components/RunScriptOnPreCastEnded.md" >})
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrosttArrow_MultiShot_Group.md
+++ b/content/prefabs/AB_Bandit_FrosttArrow_MultiShot_Group.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `2134585360`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,17 +70,17 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Shared.DamageReductionPerTarget](/components/DamageReductionPerTarget)
+- [ProjectM.Shared.DamageReductionPerTarget]({< relref "components/DamageReductionPerTarget.md" >})
   - `HitResetTimer: 0.5`
   - `ReductionModifier: 0.3`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -89,25 +89,25 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 2134585360`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Shared.DamageReductionPerTargetElement](/components/DamageReductionPerTargetElement)
+- [ProjectM.Shared.DamageReductionPerTargetElement]({< relref "components/DamageReductionPerTargetElement.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_FrosttArrow_MultiShot_Cast PrefabGuid(-895811403)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 16`
@@ -243,7 +243,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -266,16 +266,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrosttArrow_MultiShot_Hard_Cast.md
+++ b/content/prefabs/AB_Bandit_FrosttArrow_MultiShot_Hard_Cast.md
@@ -11,71 +11,71 @@ layout: default
 
 **GUID:** `-1374239147`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_FrosttArrow_MultiShot_Hard_Cast PrefabGuid(-1374239147)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 1.6`
   - `PostCastTime: 1`
   - `HideCastBar: True`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityAimPrediction](/components/AbilityAimPrediction)
+- [ProjectM.AbilityAimPrediction]({< relref "components/AbilityAimPrediction.md" >})
   - `AimPredictionFactor: 0.5`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 4.5`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -84,7 +84,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -93,24 +93,24 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0.1`
   - `Duration: 3.1`
   - `OutDuration: 0.1`
   - `UseCastDuration: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 0`
   - `Max: 17`
 
-- [ProjectM.Shared.SpellModSetComponent](/components/SpellModSetComponent)
+- [ProjectM.Shared.SpellModSetComponent]({< relref "components/SpellModSetComponent.md" >})
   - `SpellMods: SpellModSet`
   - `SyncId: 0`
   - `Mod0: SpellMod`
@@ -139,14 +139,14 @@ layout: default
   - `Power: 0`
   - `Count: 0`
 
-- [ProjectM.Gameplay.Scripting.Script_MultiShot_Cast_DataServer](/components/Script_MultiShot_Cast_DataServer)
+- [ProjectM.Gameplay.Scripting.Script_MultiShot_Cast_DataServer]({< relref "components/Script_MultiShot_Cast_DataServer.md" >})
   - `Angle: 1.0471976`
   - `OffsetAllAngles: 0`
   - `NewProjectile: AB_Bandit_FrosttArrow_MultiShot_Projectile PrefabGuid(1042909452)`
   - `Count: 5`
   - `Condition: None`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -155,14 +155,14 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1374239147`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 85`
@@ -310,7 +310,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -333,18 +333,18 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.RunScriptOnPreCastEnded](/components/RunScriptOnPreCastEnded)
+- [ProjectM.RunScriptOnPreCastEnded]({< relref "components/RunScriptOnPreCastEnded.md" >})
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_FrosttArrow_MultiShot_Hard_Group.md
+++ b/content/prefabs/AB_Bandit_FrosttArrow_MultiShot_Hard_Group.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `-1871956083`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,17 +70,17 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Shared.DamageReductionPerTarget](/components/DamageReductionPerTarget)
+- [ProjectM.Shared.DamageReductionPerTarget]({< relref "components/DamageReductionPerTarget.md" >})
   - `HitResetTimer: 0.5`
   - `ReductionModifier: 0.3`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -89,25 +89,25 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1871956083`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Shared.DamageReductionPerTargetElement](/components/DamageReductionPerTargetElement)
+- [ProjectM.Shared.DamageReductionPerTargetElement]({< relref "components/DamageReductionPerTargetElement.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_FrosttArrow_MultiShot_Hard_Cast PrefabGuid(-1374239147)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 141`
@@ -243,7 +243,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -266,16 +266,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Hunter_Bow_Cast.md
+++ b/content/prefabs/AB_Bandit_Hunter_Bow_Cast.md
@@ -11,73 +11,73 @@ layout: default
 
 **GUID:** `1547925762`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Hunter_Bow_Cast PrefabGuid(1547925762)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityDirectionInaccuracy](/components/AbilityDirectionInaccuracy)
+- [ProjectM.AbilityDirectionInaccuracy]({< relref "components/AbilityDirectionInaccuracy.md" >})
   - `MaxDegrees: 10`
   - `CurrentDegrees: 0`
   - `OnlyOnMovingTargets: True`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 1.8`
   - `PostCastTime: 0.5`
   - `HideCastBar: True`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 1`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 2.5`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -86,7 +86,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -95,20 +95,20 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0.2`
   - `Duration: 2.2`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -117,10 +117,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1547925762`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Hunter_Bow_Projectile PrefabGuid(1802976129)`
@@ -131,11 +131,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 2`
@@ -283,7 +283,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -306,16 +306,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Hunter_Bow_Group.md
+++ b/content/prefabs/AB_Bandit_Hunter_Bow_Group.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `-39311902`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,23 +85,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -39311902`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Hunter_Bow_Cast PrefabGuid(1547925762)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 226`
@@ -237,7 +237,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -260,16 +260,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Hunter_Roll_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_Hunter_Roll_AbilityGroup.md
@@ -11,41 +11,41 @@ layout: default
 
 **GUID:** `564244811`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityChargesState](/components/AbilityChargesState)
+- [ProjectM.AbilityChargesState]({< relref "components/AbilityChargesState.md" >})
   - `ChargeTime: 0`
   - `CurrentCharges: 3`
 
-- [ProjectM.AbilityChargesData](/components/AbilityChargesData)
+- [ProjectM.AbilityChargesData]({< relref "components/AbilityChargesData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `ChargeUpTime: 6`
   - `MaxCharges: 3`
   - `IgnoreCooldownModifier: False`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -55,10 +55,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -67,7 +67,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -76,13 +76,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_cjbjeehdbk`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -91,23 +91,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 564244811`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Hunter_Roll_CastAndRoll PrefabGuid(828882973)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 75`
@@ -267,7 +267,7 @@ layout: default
 
 - **52 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -299,16 +299,16 @@ layout: default
 - **[9]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Hunter_Roll_CastAndRoll.md
+++ b/content/prefabs/AB_Bandit_Hunter_Roll_CastAndRoll.md
@@ -11,82 +11,82 @@ layout: default
 
 **GUID:** `828882973`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.HideWeapon](/components/HideWeapon)
+- [ProjectM.HideWeapon]({< relref "components/HideWeapon.md" >})
   - `HideWeaponSequenceGUID: SequenceGUID 1136240177`
   - `HideWeaponState: SequenceState`
   - `Id: Entity(0:0)`
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Hunter_Roll_CastAndRoll PrefabGuid(828882973)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit_IgnoreInCombat`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityIgnoreSettings](/components/AbilityIgnoreSettings)
+- [ProjectM.AbilityIgnoreSettings]({< relref "components/AbilityIgnoreSettings.md" >})
   - `IgnorePostCast: True`
   - `IgnoreGlobalCooldown: True`
   - `IgnoreAbilityImpair: False`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 8`
   - `InterruptLowerPriority: True`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 0.5`
   - `PostCastTime: 0.2`
   - `HideCastBar: True`
 
-- [ProjectM.ChangeKnockbackResistanceDuringCast](/components/ChangeKnockbackResistanceDuringCast)
+- [ProjectM.ChangeKnockbackResistanceDuringCast]({< relref "components/ChangeKnockbackResistanceDuringCast.md" >})
   - `KnockbackResistanceIndex: 13`
   - `ModificationId: Unset`
 
-- [ProjectM.HideWeaponDuringCast](/components/HideWeaponDuringCast)
+- [ProjectM.HideWeaponDuringCast]({< relref "components/HideWeaponDuringCast.md" >})
   - `CastStartTime: 0`
   - `Duration: 1`
   - `CastStartCounter: 0`
   - `Type: ProjectM.HideWeaponDuringCastType CastAndPostCast`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 8`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -95,7 +95,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -104,20 +104,20 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0.4`
   - `InDuration: 0`
   - `Duration: 0.6`
   - `OutDuration: 0.7`
   - `UseCastDuration: False`
 
-- [ProjectM.Network.MoveDuringCastData](/components/MoveDuringCastData)
+- [ProjectM.Network.MoveDuringCastData]({< relref "components/MoveDuringCastData.md" >})
   - `ManualDuration: 0`
   - `ForceMovementLength: 4.75`
   - `CurveX: ProjectM.CurveReference ProjectM.CurveReference`
@@ -134,11 +134,11 @@ layout: default
   - `IgnoreMovementImpair: False`
   - `IgnoreMovementSpeedChanges: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 2`
   - `Max: 4`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -147,14 +147,14 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 828882973`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 29`
@@ -302,7 +302,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -325,16 +325,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_CallWolf_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_Leader_CallWolf_AbilityGroup.md
@@ -11,31 +11,31 @@ layout: default
 
 **GUID:** `-1854347593`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -45,10 +45,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -57,7 +57,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -66,13 +66,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -81,23 +81,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1854347593`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Leader_CallWolf_Cast PrefabGuid(-1437515280)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 183`
@@ -233,7 +233,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -256,16 +256,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_CallWolf_Cast.md
+++ b/content/prefabs/AB_Bandit_Leader_CallWolf_Cast.md
@@ -11,68 +11,68 @@ layout: default
 
 **GUID:** `-1437515280`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Leader_CallWolf_Cast PrefabGuid(-1437515280)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 2`
   - `PostCastTime: 1.5`
   - `HideCastBar: False`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 150`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 2`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -81,7 +81,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -90,20 +90,20 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0.1`
   - `Duration: 4`
   - `OutDuration: 0.1`
   - `UseCastDuration: False`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -112,10 +112,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1437515280`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Leader_CallWolf_Summon PrefabGuid(-419870015)`
@@ -126,11 +126,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 240`
@@ -278,7 +278,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -301,16 +301,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_Crossbow_Cast.md
+++ b/content/prefabs/AB_Bandit_Leader_Crossbow_Cast.md
@@ -11,73 +11,73 @@ layout: default
 
 **GUID:** `1956190540`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Leader_Crossbow_Cast PrefabGuid(1956190540)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityDirectionInaccuracy](/components/AbilityDirectionInaccuracy)
+- [ProjectM.AbilityDirectionInaccuracy]({< relref "components/AbilityDirectionInaccuracy.md" >})
   - `MaxDegrees: 15`
   - `CurrentDegrees: 0`
   - `OnlyOnMovingTargets: True`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 2.5`
   - `PostCastTime: 0.7`
   - `HideCastBar: True`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 4`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -86,7 +86,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -95,24 +95,24 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0.1`
   - `Duration: 3`
   - `OutDuration: 0.1`
   - `UseCastDuration: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 0`
   - `Max: 10`
 
-- [ProjectM.Shared.SpellModSetComponent](/components/SpellModSetComponent)
+- [ProjectM.Shared.SpellModSetComponent]({< relref "components/SpellModSetComponent.md" >})
   - `SpellMods: SpellModSet`
   - `SyncId: 0`
   - `Mod0: SpellMod`
@@ -141,14 +141,14 @@ layout: default
   - `Power: 0`
   - `Count: 0`
 
-- [ProjectM.Gameplay.Scripting.Script_MultiShot_Cast_DataServer](/components/Script_MultiShot_Cast_DataServer)
+- [ProjectM.Gameplay.Scripting.Script_MultiShot_Cast_DataServer]({< relref "components/Script_MultiShot_Cast_DataServer.md" >})
   - `Angle: 0.5235988`
   - `OffsetAllAngles: 0`
   - `NewProjectile: AB_Bandit_Leader_Crossbow_Projectile PrefabGuid(-269688030)`
   - `Count: 5`
   - `Condition: None`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -157,14 +157,14 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1956190540`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 76`
@@ -312,7 +312,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -335,18 +335,18 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.RunScriptOnPreCastEnded](/components/RunScriptOnPreCastEnded)
+- [ProjectM.RunScriptOnPreCastEnded]({< relref "components/RunScriptOnPreCastEnded.md" >})
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_Crossbow_Group.md
+++ b/content/prefabs/AB_Bandit_Leader_Crossbow_Group.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `-589722860`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,23 +85,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -589722860`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Leader_Crossbow_Cast PrefabGuid(1956190540)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 20`
@@ -237,7 +237,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -260,16 +260,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_OnAggro_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_Leader_OnAggro_AbilityGroup.md
@@ -11,31 +11,31 @@ layout: default
 
 **GUID:** `1567999366`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -45,10 +45,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -57,7 +57,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -66,27 +66,27 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [Unity.Transforms.Rotation](/components/Rotation)
+- [Unity.Transforms.Rotation]({< relref "components/Rotation.md" >})
   - `Value: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.Translation](/components/Translation)
+- [Unity.Transforms.Translation]({< relref "components/Translation.md" >})
   - `Value: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
 
-- [Unity.Transforms.LocalToWorld](/components/LocalToWorld)
+- [Unity.Transforms.LocalToWorld]({< relref "components/LocalToWorld.md" >})
   - `Value: Unity.Mathematics.float4x4 float4x4(1f, 0f, 0f, 0f,  0f, 1f, 0f, 0f,  0f, 0f, 1f, 0f,  0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.LocalTransform](/components/LocalTransform)
+- [Unity.Transforms.LocalTransform]({< relref "components/LocalTransform.md" >})
   - `Position: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
   - `Scale: 1`
   - `Rotation: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -95,23 +95,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1567999366`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Leader_OnAggro_Cast PrefabGuid(1304417048)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 134`
@@ -247,7 +247,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -270,18 +270,18 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.DisableWhenNoPlayersInRange](/components/DisableWhenNoPlayersInRange)
+- [ProjectM.DisableWhenNoPlayersInRange]({< relref "components/DisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_OnAggro_Cast.md
+++ b/content/prefabs/AB_Bandit_Leader_OnAggro_Cast.md
@@ -11,67 +11,67 @@ layout: default
 
 **GUID:** `1304417048`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Leader_OnAggro_Cast PrefabGuid(1304417048)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityIgnoreSettings](/components/AbilityIgnoreSettings)
+- [ProjectM.AbilityIgnoreSettings]({< relref "components/AbilityIgnoreSettings.md" >})
   - `IgnorePostCast: False`
   - `IgnoreGlobalCooldown: False`
   - `IgnoreAbilityImpair: False`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 0.4`
   - `PostCastTime: 0.1`
   - `HideCastBar: True`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 1`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -80,7 +80,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -89,13 +89,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.MoveDuringCastData](/components/MoveDuringCastData)
+- [ProjectM.Network.MoveDuringCastData]({< relref "components/MoveDuringCastData.md" >})
   - `ManualDuration: 0`
   - `ForceMovementLength: 0`
   - `CurveX: ProjectM.CurveReference ProjectM.CurveReference`
@@ -112,25 +112,25 @@ layout: default
   - `IgnoreMovementImpair: False`
   - `IgnoreMovementSpeedChanges: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 0`
   - `Max: 30`
 
-- [Unity.Transforms.Rotation](/components/Rotation)
+- [Unity.Transforms.Rotation]({< relref "components/Rotation.md" >})
   - `Value: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.Translation](/components/Translation)
+- [Unity.Transforms.Translation]({< relref "components/Translation.md" >})
   - `Value: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
 
-- [Unity.Transforms.LocalToWorld](/components/LocalToWorld)
+- [Unity.Transforms.LocalToWorld]({< relref "components/LocalToWorld.md" >})
   - `Value: Unity.Mathematics.float4x4 float4x4(1f, 0f, 0f, 0f,  0f, 1f, 0f, 0f,  0f, 0f, 1f, 0f,  0f, 0f, 0f, 1f)`
 
-- [Unity.Transforms.LocalTransform](/components/LocalTransform)
+- [Unity.Transforms.LocalTransform]({< relref "components/LocalTransform.md" >})
   - `Position: Unity.Mathematics.float3 float3(0f, 0f, 0f)`
   - `Scale: 1`
   - `Rotation: Unity.Mathematics.quaternion quaternion(0f, 0f, 0f, 1f)`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -139,14 +139,14 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1304417048`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 24`
@@ -294,7 +294,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -317,20 +317,20 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.IgnoreInCombatBuff](/components/IgnoreInCombatBuff)
+- [ProjectM.IgnoreInCombatBuff]({< relref "components/IgnoreInCombatBuff.md" >})
 
-- [ProjectM.DisableWhenNoPlayersInRange](/components/DisableWhenNoPlayersInRange)
+- [ProjectM.DisableWhenNoPlayersInRange]({< relref "components/DisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_QuickDraw_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_Leader_QuickDraw_AbilityGroup.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `-67405040`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,23 +85,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -67405040`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Leader_QuickDraw_Cast PrefabGuid(-1144749945)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 16`
@@ -237,7 +237,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -260,16 +260,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_QuickDraw_Buff.md
+++ b/content/prefabs/AB_Bandit_Leader_QuickDraw_Buff.md
@@ -11,20 +11,20 @@ layout: default
 
 **GUID:** `-1406264844`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.Buff](/components/Buff)
+- [ProjectM.Buff]({< relref "components/Buff.md" >})
   - `StartTimeUnmodified: 0`
   - `Target: Entity(0:0)`
   - `BuffType: ProjectM.BuffType Replace`
@@ -36,33 +36,33 @@ layout: default
   - `OneInstancePerOwner: False`
   - `BuffEffectType: ProjectM.BuffEffectType Debuff`
 
-- [ProjectM.ModifyMovementSpeedBuff](/components/ModifyMovementSpeedBuff)
+- [ProjectM.ModifyMovementSpeedBuff]({< relref "components/ModifyMovementSpeedBuff.md" >})
   - `MoveSpeed: 0.75`
   - `Curve: ProjectM.CurveReference ProjectM.CurveReference`
   - `MultiplyAdd: False`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.Age](/components/Age)
+- [ProjectM.Age]({< relref "components/Age.md" >})
   - `Value: 0`
 
-- [ProjectM.BuffCategory](/components/BuffCategory)
+- [ProjectM.BuffCategory]({< relref "components/BuffCategory.md" >})
   - `Level: 0`
   - `Groups: ProjectM.BuffCategoryFlag None`
   - `KeepOldest: False`
 
-- [ProjectM.LifeTime](/components/LifeTime)
+- [ProjectM.LifeTime]({< relref "components/LifeTime.md" >})
   - `Duration: 7`
   - `EndAction: ProjectM.LifeTimeEndAction Destroy`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -71,13 +71,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_ajchjhccfg`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -86,10 +86,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1406264844`
 
-- [ProjectM.CreateGameplayEventsOnDestroy](/components/CreateGameplayEventsOnDestroy)
+- [ProjectM.CreateGameplayEventsOnDestroy]({< relref "components/CreateGameplayEventsOnDestroy.md" >})
 
 - **[0]**
   - `EventId: Local - -1285857012`
@@ -97,7 +97,7 @@ layout: default
   - `SpecificDestroyReason: False`
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.ApplyBuffOnGameplayEvent](/components/ApplyBuffOnGameplayEvent)
+- [ProjectM.ApplyBuffOnGameplayEvent]({< relref "components/ApplyBuffOnGameplayEvent.md" >})
 
 - **[0]**
   - `BuffTarget: ProjectM.ApplyBuffTarget EventTarget`
@@ -114,7 +114,7 @@ layout: default
   - `ConsumeConditional: None`
   - `CustomAbilitySpellModsSource: GUID Not Found`
 
-- [ProjectM.GameplayEventIdMapping](/components/GameplayEventIdMapping)
+- [ProjectM.GameplayEventIdMapping]({< relref "components/GameplayEventIdMapping.md" >})
 
 - **[0]**
   - `NextTriggerTime: 0`
@@ -124,7 +124,7 @@ layout: default
   - `CurrentTriggers: 0`
   - `TriggerMultipleTimes: False`
 
-- [ProjectM.GameplayEventListeners](/components/GameplayEventListeners)
+- [ProjectM.GameplayEventListeners]({< relref "components/GameplayEventListeners.md" >})
 
 - **[0]**
   - `EventIdIndex: 0`
@@ -133,7 +133,7 @@ layout: default
   - `GameplayEventType: ProjectM.GameplayEventTypeEnum ApplyBuff`
   - `GameplayEventId: Local - -1285857012`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 244`
@@ -329,7 +329,7 @@ layout: default
 
 - **64 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -361,12 +361,12 @@ layout: default
 - **[9]**
   - `Value: -1`
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_QuickDraw_Cast.md
+++ b/content/prefabs/AB_Bandit_Leader_QuickDraw_Cast.md
@@ -11,72 +11,72 @@ layout: default
 
 **GUID:** `-1144749945`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Leader_QuickDraw_Cast PrefabGuid(-1144749945)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 80`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 3`
   - `PostCastTime: 0.2`
   - `HideCastBar: True`
 
-- [ProjectM.ChangeKnockbackResistanceDuringCast](/components/ChangeKnockbackResistanceDuringCast)
+- [ProjectM.ChangeKnockbackResistanceDuringCast]({< relref "components/ChangeKnockbackResistanceDuringCast.md" >})
   - `KnockbackResistanceIndex: 9`
   - `ModificationId: Unset`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 0.5`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0.3`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -85,7 +85,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -94,20 +94,20 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0`
   - `Duration: 3.5`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -116,10 +116,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1144749945`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Leader_QuickDraw_Buff PrefabGuid(-1406264844)`
@@ -130,11 +130,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 135`
@@ -282,7 +282,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -305,16 +305,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_QuickDraw_Stagger_Debuff.md
+++ b/content/prefabs/AB_Bandit_Leader_QuickDraw_Stagger_Debuff.md
@@ -11,25 +11,25 @@ layout: default
 
 **GUID:** `2013098681`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.HideWeapon](/components/HideWeapon)
+- [ProjectM.HideWeapon]({< relref "components/HideWeapon.md" >})
   - `HideWeaponSequenceGUID: SequenceGUID 1136240177`
   - `HideWeaponState: SequenceState`
   - `Id: Entity(0:0)`
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.Buff](/components/Buff)
+- [ProjectM.Buff]({< relref "components/Buff.md" >})
   - `StartTimeUnmodified: 0`
   - `Target: Entity(0:0)`
   - `BuffType: ProjectM.BuffType Replace`
@@ -41,38 +41,38 @@ layout: default
   - `OneInstancePerOwner: False`
   - `BuffEffectType: ProjectM.BuffEffectType Debuff`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.Age](/components/Age)
+- [ProjectM.Age]({< relref "components/Age.md" >})
   - `Value: 0`
 
-- [ProjectM.BuffCategory](/components/BuffCategory)
+- [ProjectM.BuffCategory]({< relref "components/BuffCategory.md" >})
   - `Level: 0`
   - `Groups: ProjectM.BuffCategoryFlag None`
   - `KeepOldest: False`
 
-- [ProjectM.DiminishingReturn](/components/DiminishingReturn)
+- [ProjectM.DiminishingReturn]({< relref "components/DiminishingReturn.md" >})
   - `DiminishingBuff: DiminishingReturn_Buff_Stun PrefabGuid(-160846617)`
   - `SCTPrefab: SCT_Type_Immune PrefabGuid(-1203333778)`
   - `AllowOnUnitTarget: False`
   - `AllowFromUnitOwner: False`
 
-- [ProjectM.LifeTime](/components/LifeTime)
+- [ProjectM.LifeTime]({< relref "components/LifeTime.md" >})
   - `Duration: 5`
   - `EndAction: ProjectM.LifeTimeEndAction Destroy`
 
-- [ProjectM.BuffModificationFlagData](/components/BuffModificationFlagData)
+- [ProjectM.BuffModificationFlagData]({< relref "components/BuffModificationFlagData.md" >})
   - `ModificationTypes: 1107296272`
   - `ModificationId: Unset`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -81,13 +81,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_ajchjhccfg`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -96,10 +96,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 2013098681`
 
-- [ProjectM.DiminishingReturnElement](/components/DiminishingReturnElement)
+- [ProjectM.DiminishingReturnElement]({< relref "components/DiminishingReturnElement.md" >})
 
 - **[0]**
   - `DurationFactor: 0.67`
@@ -107,7 +107,7 @@ layout: default
 - **[1]**
   - `DurationFactor: 0.33`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 185`
@@ -303,7 +303,7 @@ layout: default
 
 - **64 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -335,10 +335,10 @@ layout: default
 - **[9]**
   - `Value: -1`
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_Roll_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_Leader_Roll_AbilityGroup.md
@@ -11,41 +11,41 @@ layout: default
 
 **GUID:** `138056981`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityChargesState](/components/AbilityChargesState)
+- [ProjectM.AbilityChargesState]({< relref "components/AbilityChargesState.md" >})
   - `ChargeTime: 0`
   - `CurrentCharges: 3`
 
-- [ProjectM.AbilityChargesData](/components/AbilityChargesData)
+- [ProjectM.AbilityChargesData]({< relref "components/AbilityChargesData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `ChargeUpTime: 6`
   - `MaxCharges: 3`
   - `IgnoreCooldownModifier: False`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -55,10 +55,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -67,7 +67,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -76,13 +76,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_cjbjeehdbk`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -91,23 +91,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 138056981`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Leader_Roll_CastAndRoll PrefabGuid(814281313)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 21`
@@ -267,7 +267,7 @@ layout: default
 
 - **52 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -299,16 +299,16 @@ layout: default
 - **[9]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_Roll_CastAndRoll.md
+++ b/content/prefabs/AB_Bandit_Leader_Roll_CastAndRoll.md
@@ -11,82 +11,82 @@ layout: default
 
 **GUID:** `814281313`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.HideWeapon](/components/HideWeapon)
+- [ProjectM.HideWeapon]({< relref "components/HideWeapon.md" >})
   - `HideWeaponSequenceGUID: SequenceGUID 1136240177`
   - `HideWeaponState: SequenceState`
   - `Id: Entity(0:0)`
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Leader_Roll_CastAndRoll PrefabGuid(814281313)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit_IgnoreInCombat`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityIgnoreSettings](/components/AbilityIgnoreSettings)
+- [ProjectM.AbilityIgnoreSettings]({< relref "components/AbilityIgnoreSettings.md" >})
   - `IgnorePostCast: True`
   - `IgnoreGlobalCooldown: True`
   - `IgnoreAbilityImpair: False`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 8`
   - `InterruptLowerPriority: True`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 0.5`
   - `PostCastTime: 0.2`
   - `HideCastBar: True`
 
-- [ProjectM.ChangeKnockbackResistanceDuringCast](/components/ChangeKnockbackResistanceDuringCast)
+- [ProjectM.ChangeKnockbackResistanceDuringCast]({< relref "components/ChangeKnockbackResistanceDuringCast.md" >})
   - `KnockbackResistanceIndex: 13`
   - `ModificationId: Unset`
 
-- [ProjectM.HideWeaponDuringCast](/components/HideWeaponDuringCast)
+- [ProjectM.HideWeaponDuringCast]({< relref "components/HideWeaponDuringCast.md" >})
   - `CastStartTime: 0`
   - `Duration: 1`
   - `CastStartCounter: 0`
   - `Type: ProjectM.HideWeaponDuringCastType CastAndPostCast`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 7`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -95,7 +95,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -104,20 +104,20 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0.4`
   - `InDuration: 0`
   - `Duration: 0.6`
   - `OutDuration: 0.7`
   - `UseCastDuration: False`
 
-- [ProjectM.Network.MoveDuringCastData](/components/MoveDuringCastData)
+- [ProjectM.Network.MoveDuringCastData]({< relref "components/MoveDuringCastData.md" >})
   - `ManualDuration: 0`
   - `ForceMovementLength: 7`
   - `CurveX: ProjectM.CurveReference ProjectM.CurveReference`
@@ -134,11 +134,11 @@ layout: default
   - `IgnoreMovementImpair: False`
   - `IgnoreMovementSpeedChanges: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 2`
   - `Max: 4`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -147,14 +147,14 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 814281313`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 97`
@@ -302,7 +302,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -325,16 +325,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_Strafe_Cast.md
+++ b/content/prefabs/AB_Bandit_Leader_Strafe_Cast.md
@@ -11,72 +11,72 @@ layout: default
 
 **GUID:** `-1478907722`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Leader_Strafe_Cast PrefabGuid(-1478907722)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 0.25`
   - `PostCastTime: 0.1`
   - `HideCastBar: True`
 
-- [ProjectM.ChangeKnockbackResistanceDuringCast](/components/ChangeKnockbackResistanceDuringCast)
+- [ProjectM.ChangeKnockbackResistanceDuringCast]({< relref "components/ChangeKnockbackResistanceDuringCast.md" >})
   - `KnockbackResistanceIndex: 9`
   - `ModificationId: Unset`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 0.5`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0.1`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -85,7 +85,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -94,24 +94,24 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0`
   - `Duration: 1`
   - `OutDuration: 0`
   - `UseCastDuration: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 4.3`
   - `Max: 10`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -120,10 +120,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1478907722`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Leader_Strafe_Projectile PrefabGuid(-835823412)`
@@ -134,11 +134,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 182`
@@ -286,7 +286,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -309,16 +309,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_Strafe_Group.md
+++ b/content/prefabs/AB_Bandit_Leader_Strafe_Group.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `920868547`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,23 +85,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 920868547`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Leader_Strafe_Cast PrefabGuid(-1478907722)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 195`
@@ -237,7 +237,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -260,16 +260,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_ThrowNet_Buff.md
+++ b/content/prefabs/AB_Bandit_Leader_ThrowNet_Buff.md
@@ -11,20 +11,20 @@ layout: default
 
 **GUID:** `1167706357`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.Buff](/components/Buff)
+- [ProjectM.Buff]({< relref "components/Buff.md" >})
   - `StartTimeUnmodified: 0`
   - `Target: Entity(0:0)`
   - `BuffType: ProjectM.BuffType Replace`
@@ -36,32 +36,32 @@ layout: default
   - `OneInstancePerOwner: False`
   - `BuffEffectType: ProjectM.BuffEffectType Debuff`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.Age](/components/Age)
+- [ProjectM.Age]({< relref "components/Age.md" >})
   - `Value: 0`
 
-- [ProjectM.BuffCategory](/components/BuffCategory)
+- [ProjectM.BuffCategory]({< relref "components/BuffCategory.md" >})
   - `Level: 0`
   - `Groups: ProjectM.BuffCategoryFlag Slow`
   - `KeepOldest: False`
 
-- [ProjectM.LifeTime](/components/LifeTime)
+- [ProjectM.LifeTime]({< relref "components/LifeTime.md" >})
   - `Duration: 2`
   - `EndAction: ProjectM.LifeTimeEndAction Destroy`
 
-- [ProjectM.BuffModificationFlagData](/components/BuffModificationFlagData)
+- [ProjectM.BuffModificationFlagData]({< relref "components/BuffModificationFlagData.md" >})
   - `ModificationTypes: 16`
   - `ModificationId: Unset`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_ajchjhccfg`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,10 +85,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1167706357`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 245`
@@ -284,7 +284,7 @@ layout: default
 
 - **64 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -316,10 +316,10 @@ layout: default
 - **[9]**
   - `Value: -1`
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_ThrowNet_Cast.md
+++ b/content/prefabs/AB_Bandit_Leader_ThrowNet_Cast.md
@@ -11,85 +11,85 @@ layout: default
 
 **GUID:** `-1795398926`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.HideWeapon](/components/HideWeapon)
+- [ProjectM.HideWeapon]({< relref "components/HideWeapon.md" >})
   - `HideWeaponSequenceGUID: SequenceGUID 1136240177`
   - `HideWeaponState: SequenceState`
   - `Id: Entity(0:0)`
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityState](/components/AbilityState)
+- [ProjectM.AbilityState]({< relref "components/AbilityState.md" >})
   - `AbilityId: AB_Bandit_Leader_ThrowNet_Cast PrefabGuid(-1795398926)`
   - `GroupEntity: NetworkedEntity(0:0)`
   - `AbilityTypeFlag: ProjectM.AbilityTypeFlag AbilityKit, AbilityKit_BreakStealth`
 
-- [ProjectM.Network.ModifyRotationDuringCast](/components/ModifyRotationDuringCast)
+- [ProjectM.Network.ModifyRotationDuringCast]({< relref "components/ModifyRotationDuringCast.md" >})
   - `CastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `PostCastRotationData: ProjectM.Network.ModifyRotation ProjectM.Network.ModifyRotation`
   - `CastModifyRotationEntity: Entity(0:0)`
   - `PostCastModifyRotationEntity: Entity(0:0)`
 
-- [ProjectM.AbilityPositionInaccuracy](/components/AbilityPositionInaccuracy)
+- [ProjectM.AbilityPositionInaccuracy]({< relref "components/AbilityPositionInaccuracy.md" >})
   - `CurrentOffset: Unity.Mathematics.float2 float2(0f, 0f)`
   - `MinDistance: 0`
   - `MaxDistance: 2`
   - `OnlyOnMovingTargets: True`
 
-- [ProjectM.AbilityPriority](/components/AbilityPriority)
+- [ProjectM.AbilityPriority]({< relref "components/AbilityPriority.md" >})
   - `Priority: 0`
   - `InterruptLowerPriority: False`
   - `InterruptHigherPriority: False`
 
-- [ProjectM.AbilityCastTimeData](/components/AbilityCastTimeData)
+- [ProjectM.AbilityCastTimeData]({< relref "components/AbilityCastTimeData.md" >})
   - `MaxCastTime: 1`
   - `PostCastTime: 0.6`
   - `HideCastBar: True`
 
-- [ProjectM.HideWeaponDuringCast](/components/HideWeaponDuringCast)
+- [ProjectM.HideWeaponDuringCast]({< relref "components/HideWeaponDuringCast.md" >})
   - `CastStartTime: 0`
   - `Duration: 1`
   - `CastStartCounter: 0`
   - `Type: ProjectM.HideWeaponDuringCastType CastAndPostCast`
 
-- [ProjectM.AbilityInterruptData](/components/AbilityInterruptData)
+- [ProjectM.AbilityInterruptData]({< relref "components/AbilityInterruptData.md" >})
   - `CooldownOnInterrupt: 0.5`
   - `InterruptTypes: ProjectM.InterruptTypes ManualInterrupt`
   - `FullCooldownOnInterrupt: False`
   - `FullCooldownModifier: 1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityCooldownState](/components/AbilityCooldownState)
+- [ProjectM.AbilityCooldownState]({< relref "components/AbilityCooldownState.md" >})
   - `CooldownEndTime: 0`
   - `CurrentCooldown: 0`
 
-- [ProjectM.AbilityCooldownData](/components/AbilityCooldownData)
+- [ProjectM.AbilityCooldownData]({< relref "components/AbilityCooldownData.md" >})
   - `ShowInteractCooldownHUD: False`
   - `IgnoreCooldownModifier: False`
   - `Cooldown: 9`
 
-- [ProjectM.GlobalCooldown](/components/GlobalCooldown)
+- [ProjectM.GlobalCooldown]({< relref "components/GlobalCooldown.md" >})
   - `Value: 0`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -98,7 +98,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -107,24 +107,24 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acgddgdckdd`
 
-- [ProjectM.Network.ModifyMovementDuringCastData](/components/ModifyMovementDuringCastData)
+- [ProjectM.Network.ModifyMovementDuringCastData]({< relref "components/ModifyMovementDuringCastData.md" >})
   - `MovementSpeedMultiplier: 0`
   - `InDuration: 0.15`
   - `Duration: 1.7`
   - `OutDuration: 0.1`
   - `UseCastDuration: False`
 
-- [ProjectM.Behaviours.AbilityRange](/components/AbilityRange)
+- [ProjectM.Behaviours.AbilityRange]({< relref "components/AbilityRange.md" >})
   - `Min: 0`
   - `Max: 9`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -133,10 +133,10 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: -1795398926`
 
-- [ProjectM.AbilitySpawnPrefabOnCast](/components/AbilitySpawnPrefabOnCast)
+- [ProjectM.AbilitySpawnPrefabOnCast]({< relref "components/AbilitySpawnPrefabOnCast.md" >})
 
 - **[0]**
   - `SpawnPrefab: AB_Bandit_Leader_ThrowNet_Throw PrefabGuid(-293977621)`
@@ -147,11 +147,11 @@ layout: default
   - `Condition: None`
   - `HoverMaxDistance: 900`
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 242`
@@ -299,7 +299,7 @@ layout: default
 
 - **48 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -322,16 +322,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Leader_ThrowNet_Group.md
+++ b/content/prefabs/AB_Bandit_Leader_ThrowNet_Group.md
@@ -11,35 +11,35 @@ layout: default
 
 **GUID:** `1550497814`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.AbilityGroupResetComboState](/components/AbilityGroupResetComboState)
+- [ProjectM.AbilityGroupResetComboState]({< relref "components/AbilityGroupResetComboState.md" >})
   - `ComboResetTime: 0`
   - `ComboResetDuration: 2`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -49,10 +49,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -61,7 +61,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -70,13 +70,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -85,23 +85,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 1550497814`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Leader_ThrowNet_Cast PrefabGuid(-1795398926)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 22`
@@ -237,7 +237,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -260,16 +260,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})

--- a/content/prefabs/AB_Bandit_Mugger_Block_AbilityGroup.md
+++ b/content/prefabs/AB_Bandit_Mugger_Block_AbilityGroup.md
@@ -11,31 +11,31 @@ layout: default
 
 **GUID:** `616797239`
 
-**Categories:** [AB](/prefabs/AB), [All](/prefabs/All)
+**Categories:** [AB]({< relref "prefabs/AB.md" >}), [All]({< relref "prefabs/All.md" >})
 
 ## Components
 
-- [ProjectM.Attach](/components/Attach)
+- [ProjectM.Attach]({< relref "components/Attach.md" >})
   - `Parent: Entity(0:0)`
 
-- [ProjectM.EntityOwner](/components/EntityOwner)
+- [ProjectM.EntityOwner]({< relref "components/EntityOwner.md" >})
   - `Owner: Entity(0:0)`
 
-- [ProjectM.EntityCreator](/components/EntityCreator)
+- [ProjectM.EntityCreator]({< relref "components/EntityCreator.md" >})
   - `Creator: NetworkedEntity(0:0)`
 
-- [ProjectM.AbilityGroupState](/components/AbilityGroupState)
+- [ProjectM.AbilityGroupState]({< relref "components/AbilityGroupState.md" >})
   - `Character: NetworkedEntity(0:0)`
   - `GroupId: GUID Not Found`
   - `SlotIndex: -1`
 
-- [ProjectM.DestroyData](/components/DestroyData)
+- [ProjectM.DestroyData]({< relref "components/DestroyData.md" >})
   - `DestroyReason: ProjectM.DestroyReason Default`
 
-- [ProjectM.DestroyState](/components/DestroyState)
+- [ProjectM.DestroyState]({< relref "components/DestroyState.md" >})
   - `Value: ProjectM.DestroyStateEnum NotDestroyed`
 
-- [ProjectM.AbilityGroupInfo](/components/AbilityGroupInfo)
+- [ProjectM.AbilityGroupInfo]({< relref "components/AbilityGroupInfo.md" >})
   - `ReleaseCastQueueTime: 0.3`
   - `CastCondition: None`
   - `HoverCondition: None`
@@ -45,10 +45,10 @@ layout: default
   - `InputType: ProjectM.AbilityInputCastType Default`
   - `Target: ProjectM.AbilitySpawnTarget Owner`
 
-- [ProjectM.Network.Networked](/components/Networked)
+- [ProjectM.Network.Networked]({< relref "components/Networked.md" >})
   - `CreateFrame: 0`
 
-- [ProjectM.Network.UpToDateUserBitMask](/components/UpToDateUserBitMask)
+- [ProjectM.Network.UpToDateUserBitMask]({< relref "components/UpToDateUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -57,7 +57,7 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.SyncToUserBitMask](/components/SyncToUserBitMask)
+- [ProjectM.Network.SyncToUserBitMask]({< relref "components/SyncToUserBitMask.md" >})
   - `Value: ProjectM.Network.UserBitMask128 00000000000000000000000000000000`
 
 - **00000000000000000000000000000000**
@@ -66,13 +66,13 @@ layout: default
 
 - **00000000000000000000000000000000**
 
-- [ProjectM.Network.FrameChanged](/components/FrameChanged)
+- [ProjectM.Network.FrameChanged]({< relref "components/FrameChanged.md" >})
   - `Value: -1`
 
-- [ProjectM.Network.NetworkSnapshot](/components/NetworkSnapshot)
+- [ProjectM.Network.NetworkSnapshot]({< relref "components/NetworkSnapshot.md" >})
   - `Type: ProjectM.Network.NetworkSnapshotType Snapshot_acigkbdedfb`
 
-- [ProjectM.Network.NetworkId](/components/NetworkId)
+- [ProjectM.Network.NetworkId]({< relref "components/NetworkId.md" >})
   - `Normal_Index: 0`
   - `Normal_Generation: 0`
   - `MegaStatic_StaticTransformIndex: 0`
@@ -81,23 +81,23 @@ layout: default
   - `MegaStatic_PrefabGUID: 0`
   - `Type: ProjectM.Network.NetworkIdType None`
 
-- [Stunlock.Core.PrefabGUID](/components/PrefabGUID)
+- [Stunlock.Core.PrefabGUID]({< relref "components/PrefabGUID.md" >})
   - `_Value: 616797239`
 
-- [ProjectM.AbilityStateBuffer](/components/AbilityStateBuffer)
+- [ProjectM.AbilityStateBuffer]({< relref "components/AbilityStateBuffer.md" >})
 
-- [ProjectM.Network.SyncToUserBuffer](/components/SyncToUserBuffer)
+- [ProjectM.Network.SyncToUserBuffer]({< relref "components/SyncToUserBuffer.md" >})
 
-- [ProjectM.Network.Snapshot_AbilityStateBuffer](/components/Snapshot_AbilityStateBuffer)
+- [ProjectM.Network.Snapshot_AbilityStateBuffer]({< relref "components/Snapshot_AbilityStateBuffer.md" >})
 
-- [ProjectM.AbilityCastCondition](/components/AbilityCastCondition)
+- [ProjectM.AbilityCastCondition]({< relref "components/AbilityCastCondition.md" >})
 
-- [ProjectM.AbilityGroupStartAbilitiesBuffer](/components/AbilityGroupStartAbilitiesBuffer)
+- [ProjectM.AbilityGroupStartAbilitiesBuffer]({< relref "components/AbilityGroupStartAbilitiesBuffer.md" >})
 
 - **[0]**
   - `PrefabGUID: AB_Bandit_Mugger_Block_Cast PrefabGuid(-137254439)`
 
-- [ProjectM.Network.NetSnapshot](/components/NetSnapshot)
+- [ProjectM.Network.NetSnapshot]({< relref "components/NetSnapshot.md" >})
 
 - **[0]**
   - `Value: 55`
@@ -233,7 +233,7 @@ layout: default
 
 - **44 total elements but only showing the first 36**
 
-- [ProjectM.Network.SnapshotFrameChangedBuffer](/components/SnapshotFrameChangedBuffer)
+- [ProjectM.Network.SnapshotFrameChangedBuffer]({< relref "components/SnapshotFrameChangedBuffer.md" >})
 
 - **[0]**
   - `Value: -1`
@@ -256,16 +256,16 @@ layout: default
 - **[6]**
   - `Value: -1`
 
-- [ProjectM.PreventDisableWhenNoPlayersInRange](/components/PreventDisableWhenNoPlayersInRange)
+- [ProjectM.PreventDisableWhenNoPlayersInRange]({< relref "components/PreventDisableWhenNoPlayersInRange.md" >})
 
-- [ProjectM.Network.OnlySyncToUsersTag](/components/OnlySyncToUsersTag)
+- [ProjectM.Network.OnlySyncToUsersTag]({< relref "components/OnlySyncToUsersTag.md" >})
 
-- [Unity.Entities.SpawnTag](/components/SpawnTag)
+- [Unity.Entities.SpawnTag]({< relref "components/SpawnTag.md" >})
 
-- [Unity.Entities.Prefab](/components/Prefab)
+- [Unity.Entities.Prefab]({< relref "components/Prefab.md" >})
 
-- [Unity.Entities.Simulate](/components/Simulate)
+- [Unity.Entities.Simulate]({< relref "components/Simulate.md" >})
 
-- [Unity.Entities.BlobAssetOwner](/components/BlobAssetOwner)
+- [Unity.Entities.BlobAssetOwner]({< relref "components/BlobAssetOwner.md" >})
 
-- [ProjectM.Network.NetworkSnapshotType](/components/NetworkSnapshotType)
+- [ProjectM.Network.NetworkSnapshotType]({< relref "components/NetworkSnapshotType.md" >})


### PR DESCRIPTION
## Summary
- Use relref shortcodes for prefab and component links in next 60 prefab files
- Maintain existing structure while converting root-relative links to relref

## Testing
- `scripts/check_shortcode_syntax.sh content/prefabs/AB_Bandit_Foreman_Crossbow_Hard_BloodRage_AbilityGroup.md ... AB_Bandit_Mugger_Block_AbilityGroup.md`
- `./scripts/dev.sh build` *(fails: The Relearn theme requires Hugo 0.126.3 or later)*

------
https://chatgpt.com/codex/tasks/task_e_68a094177ef4832dba3bb4382b520a42