### PR TITLE
Handle directory inputs in shortcode syntax checker

### DIFF
--- a/scripts/check_shortcode_syntax.sh
+++ b/scripts/check_shortcode_syntax.sh
@@ -7,8 +7,16 @@ set -euo pipefail
 # Add additional shortcodes to the pipe-delimited regex as needed.
 readonly ALLOWED_SHORTCODES_REGEX='(figure|highlight|relref|ref)'
 
+# Build a list of Markdown files from any provided files or directories.
+mapfile -t files < <(find "$@" -type f -name '*.md' -print)
+
+# Exit early if no matching files are found.
+if [[ ${#files[@]} -eq 0 ]]; then
+  exit 0
+fi
+
 # Look for any '{{<' occurrences not in the allowlist.
-shortcode_hits=$(grep -nF '{{<' "$@" | grep -Ev "\\{\\{<\\s*(${ALLOWED_SHORTCODES_REGEX})\\b" || true)
+shortcode_hits=$(grep -nF '{{<' "${files[@]}" | grep -Ev "\\{\\{<\\s*(${ALLOWED_SHORTCODES_REGEX})\\b" || true)
 if [[ -n "${shortcode_hits}" ]]; then
   echo "ERROR: Found disallowed angle-bracket shortcode. Use '{{% ... %}}' instead." >&2
   echo "${shortcode_hits}" >&2
@@ -16,7 +24,7 @@ if [[ -n "${shortcode_hits}" ]]; then
 fi
 
 # Look for leftover Jekyll/Liquid constructs like '{{ site.foo }}'.
-liquid_hits=$(grep -nE '\\{\\{\\s*site\\.' "$@" || true)
+liquid_hits=$(grep -nE '\\{\\{\\s*site\\.' "${files[@]}" || true)
 if [[ -n "${liquid_hits}" ]]; then
   echo "ERROR: Found Liquid template syntax '{{ site.* }}'. Convert to Hugo syntax." >&2
   echo "${liquid_hits}" >&2


### PR DESCRIPTION
## Summary
- Allow `scripts/check_shortcode_syntax.sh` to accept directories by expanding them into a Markdown file list

## Testing
- `scripts/check_shortcode_syntax.sh content/prefabs content/components content/systems`
- `./scripts/dev.sh build` *(fails: can't evaluate field Default in type page.Sites)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c76b3814832d8029ea93321015b5