### PR TITLE
Log Hugo output in dev script

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -29,10 +29,14 @@ fi
 
 case "$action" in
   serve)
-    hugo server
+    log_file="serve.log"
+    hugo server --verbose 2>&1 | tee "$log_file"
+    echo "Hugo server log stored at $log_file"
     ;;
   build)
-    hugo
+    log_file="build.log"
+    hugo --verbose 2>&1 | tee "$log_file"
+    echo "Hugo build log stored at $log_file"
     ;;
   *)
     usage


### PR DESCRIPTION
## Summary
- Capture Hugo output to log files for both build and serve modes
- Print the log file location after Hugo finishes

## Testing
- `scripts/check_shortcode_syntax.sh`
- `./scripts/dev.sh build` *(fails: tons of warnings and long log; command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d8d3ebd8832d9e1297766058b226