### PR TITLE
Add bulk relref migration script

### DIFF
--- a/scripts/bulk_relref_migrate.sh
+++ b/scripts/bulk_relref_migrate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BATCH_SIZE=${BATCH_SIZE:-25}
+LOG_DIR=${LOG_DIR:-logs/bulk_relref}
+mkdir -p "$LOG_DIR"
+
+find_paths() {
+  rg '\]\(/' "$@" -l
+}
+
+process_batch() {
+  local batch=("$@")
+  printf '%s\n' "${batch[@]}" | xargs python scripts/rewrite_root_links.py
+  scripts/check_shortcode_syntax.sh "${batch[@]}"
+  ./scripts/dev.sh build 2>&1 | tee "$LOG_DIR/build-$(date +%Y%m%d%H%M%S).log"
+  rg -q 'REF_NOT_FOUND' "$LOG_DIR"/build-* && {
+    echo "Missing refs found; check log."
+    return 1
+  }
+}
+
+main() {
+  files=($(find_paths "$@"))
+  while ((${#files[@]})); do
+    batch=("${files[@]:0:BATCH_SIZE}")
+    process_batch "${batch[@]}" || break
+    git commit -am "Migrate relrefs: ${batch[0]}…"
+    files=("${files[@]:BATCH_SIZE}")
+  done
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add helper script to migrate root-relative links in batches and build site with logging

## Testing
- `scripts/check_shortcode_syntax.sh scripts/bulk_relref_migrate.sh`
- `./scripts/dev.sh build` *(fails: can't evaluate field Default in type page.Sites)*

------
https://chatgpt.com/codex/tasks/task_e_68a10dd19548832d9c24ef3c0a92fd7c