### PR TITLE
chore: disallow relref shortcodes

### DIFF
--- a/scripts/check_shortcode_syntax.sh
+++ b/scripts/check_shortcode_syntax.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 # Shortcodes in this allowlist are permitted to use angle-bracket syntax.
 # Add additional shortcodes to the pipe-delimited regex as needed.
-readonly ALLOWED_SHORTCODES_REGEX='(figure|highlight|relref|ref)'
+readonly ALLOWED_SHORTCODES_REGEX='(figure|highlight)'
 
 # Build a list of Markdown files from any provided files or directories.
 mapfile -t files < <(find "$@" -type f -name '*.md' -print)


### PR DESCRIPTION
## Summary
- disallow `relref` and `ref` shortcodes in angle-bracket form

## Testing
- `./scripts/check_shortcode_syntax.sh content/prefabs/AB_Bandit_Leader_OnAggro_AbilityGroup.md` *(fails: disallowed `relref` shortcodes found)*
- `./scripts/dev.sh build` *(fails: multiple warnings about `relref` usage and build errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1108538f8832d8484cda24d21d027