### PR TITLE
Use single heading in prefabs list

### DIFF
--- a/layouts/prefabs/list.html
+++ b/layouts/prefabs/list.html
@@ -3,7 +3,7 @@
 {{ end }}
 
 {{ define "main" }}
-<h1>{{ .Title }} Prefabs</h1>
+<h1>{{ .Title }}</h1>
 
 {{ .Content }}
 <table>


### PR DESCRIPTION
## Summary
- Simplify prefabs list heading to use only the page title

## Testing
- `scripts/check_shortcode_syntax.sh`
- `./scripts/dev.sh build` *(fails: many "WARNING you must call the ref / relref shortcode..." messages)*

------
https://chatgpt.com/codex/tasks/task_e_68a6261bb9dc832d8b7b905e4973afa4