### PR TITLE
chore: rename prefabs index

### DIFF
--- a/content/dev/resources.md
+++ b/content/dev/resources.md
@@ -7,7 +7,7 @@ weight: 7
 
 - [**Open Source Repositories**]({{< relref "dev/open-source.md" >}})
   - The VRising modding community focuses on open-source mods to encourage learning and the development of new features. Feel free to explore and reference any of the open-source mods listed here, but please be sure to **credit the creators** and follow any relevant license requirements.
-- [**Prefabs list**]({{< relref "prefabs/index.md" >}})
+- [**Prefabs list**]({{< relref "prefabs/_index.md" >}})
   - Full list of prefabs extracted from the game.
 - [**GPT Instructions**]({{< relref "dev/gpt_instructions.md" >}})
   - Instructions to help guide responses for [C#(Rising)](https://chatgpt.com/g/g-XGdFZaBHL-c-rising).

--- a/content/prefabs/_index.md
+++ b/content/prefabs/_index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Prefabs
 has_children: true
 ---
@@ -9,11 +8,3 @@ has_children: true
 Prefabs are identifers often used in commands or configurations to refer to an object, item, effect, etc.
 
 Full list here **(warning large file)**: [all prefabs](./All) also the remainder of the prefabs with fewer than 10 in a category into [remainders prefabs](./Remainders). [Vblood Prefabs by Name](./VBloodNames).
-
-<div class="prefab-list">
-  {{ range $name, $prefab := .Site.Data.prefabs }}
-    {{ if ne $name "All" }}
-      <a class="prefab-item" href="{{ (printf "/prefabs/%s" $name) | relURL }}"><b>{{ $name }}</b> ({{ len $prefab }})</a>
-    {{ end }}
-  {{ end }}
-</div>


### PR DESCRIPTION
## Summary
- rename prefabs index to `_index.md`
- prune prefab listing to intro text only
- update developer resources link

## Testing
- `scripts/check_shortcode_syntax.sh`
- `./scripts/dev.sh build` *(fails: hugo: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a62b850610832dae9b515c98b5cd21