### PR TITLE
Expose prefab categories in sidebar

### DIFF
--- a/content/prefabs/AB.md
+++ b/content/prefabs/AB.md
@@ -3,6 +3,6 @@ layout: prefab
 title: AB
 data_file: AB
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/AI.md
+++ b/content/prefabs/AI.md
@@ -3,6 +3,6 @@ layout: prefab
 title: AI
 data_file: AI
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Ability.md
+++ b/content/prefabs/Ability.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Ability
 data_file: Ability
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Aim.md
+++ b/content/prefabs/Aim.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Aim
 data_file: Aim
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/All.md
+++ b/content/prefabs/All.md
@@ -3,6 +3,6 @@ layout: prefab
 title: All
 data_file: All
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Ascendancy.md
+++ b/content/prefabs/Ascendancy.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Ascendancy
 data_file: Ascendancy
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/BEH.md
+++ b/content/prefabs/BEH.md
@@ -3,6 +3,6 @@ layout: prefab
 title: BEH
 data_file: BEH
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/BP.md
+++ b/content/prefabs/BP.md
@@ -3,6 +3,6 @@ layout: prefab
 title: BP
 data_file: BP
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Base.md
+++ b/content/prefabs/Base.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Base
 data_file: Base
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Biome.md
+++ b/content/prefabs/Biome.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Biome
 data_file: Biome
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Blood.md
+++ b/content/prefabs/Blood.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Blood
 data_file: Blood
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Braziers.md
+++ b/content/prefabs/Braziers.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Braziers
 data_file: Braziers
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Buff.md
+++ b/content/prefabs/Buff.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Buff
 data_file: Buff
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/CHAR.md
+++ b/content/prefabs/CHAR.md
@@ -3,6 +3,6 @@ layout: prefab
 title: CHAR
 data_file: CHAR
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/CO.md
+++ b/content/prefabs/CO.md
@@ -3,6 +3,6 @@ layout: prefab
 title: CO
 data_file: CO
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Castle.md
+++ b/content/prefabs/Castle.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Castle
 data_file: Castle
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Chain.md
+++ b/content/prefabs/Chain.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Chain
 data_file: Chain
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Copper.md
+++ b/content/prefabs/Copper.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Copper
 data_file: Copper
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Creature.md
+++ b/content/prefabs/Creature.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Creature
 data_file: Creature
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Critter.md
+++ b/content/prefabs/Critter.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Critter
 data_file: Critter
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Curtains.md
+++ b/content/prefabs/Curtains.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Curtains
 data_file: Curtains
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Curve.md
+++ b/content/prefabs/Curve.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Curve
 data_file: Curve
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/DG.md
+++ b/content/prefabs/DG.md
@@ -3,6 +3,6 @@ layout: prefab
 title: DG
 data_file: DG
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/DT.md
+++ b/content/prefabs/DT.md
@@ -3,6 +3,6 @@ layout: prefab
 title: DT
 data_file: DT
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Door.md
+++ b/content/prefabs/Door.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Door
 data_file: Door
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Dye.md
+++ b/content/prefabs/Dye.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Dye
 data_file: Dye
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Dynamic.md
+++ b/content/prefabs/Dynamic.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Dynamic
 data_file: Dynamic
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Dynamics.md
+++ b/content/prefabs/Dynamics.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Dynamics
 data_file: Dynamics
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/EH.md
+++ b/content/prefabs/EH.md
@@ -3,6 +3,6 @@ layout: prefab
 title: EH
 data_file: EH
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Ease.md
+++ b/content/prefabs/Ease.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Ease
 data_file: Ease
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Elris.md
+++ b/content/prefabs/Elris.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Elris
 data_file: Elris
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Equip.md
+++ b/content/prefabs/Equip.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Equip
 data_file: Equip
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Faction.md
+++ b/content/prefabs/Faction.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Faction
 data_file: Faction
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Fake.md
+++ b/content/prefabs/Fake.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Fake
 data_file: Fake
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Garden.md
+++ b/content/prefabs/Garden.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Garden
 data_file: Garden
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Gloom.md
+++ b/content/prefabs/Gloom.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Gloom
 data_file: Gloom
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Gravestone.md
+++ b/content/prefabs/Gravestone.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Gravestone
 data_file: Gravestone
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Graveyard.md
+++ b/content/prefabs/Graveyard.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Graveyard
 data_file: Graveyard
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Ground.md
+++ b/content/prefabs/Ground.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Ground
 data_file: Ground
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Illusion.md
+++ b/content/prefabs/Illusion.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Illusion
 data_file: Illusion
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Iron.md
+++ b/content/prefabs/Iron.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Iron
 data_file: Iron
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Item.md
+++ b/content/prefabs/Item.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Item
 data_file: Item
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Journal.md
+++ b/content/prefabs/Journal.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Journal
 data_file: Journal
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Map.md
+++ b/content/prefabs/Map.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Map
 data_file: Map
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Micro.md
+++ b/content/prefabs/Micro.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Micro
 data_file: Micro
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Milo.md
+++ b/content/prefabs/Milo.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Milo
 data_file: Milo
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Music.md
+++ b/content/prefabs/Music.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Music
 data_file: Music
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/NPCDeadeye.md
+++ b/content/prefabs/NPCDeadeye.md
@@ -3,6 +3,6 @@ layout: prefab
 title: NPCDeadeye
 data_file: NPCDeadeye
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/PVP.md
+++ b/content/prefabs/PVP.md
@@ -3,6 +3,6 @@ layout: prefab
 title: PVP
 data_file: PVP
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Quarry.md
+++ b/content/prefabs/Quarry.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Quarry
 data_file: Quarry
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Random.md
+++ b/content/prefabs/Random.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Random
 data_file: Random
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Recipe.md
+++ b/content/prefabs/Recipe.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Recipe
 data_file: Recipe
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Remainders.md
+++ b/content/prefabs/Remainders.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Remainders
 data_file: Remainders
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Resource.md
+++ b/content/prefabs/Resource.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Resource
 data_file: Resource
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Rock.md
+++ b/content/prefabs/Rock.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Rock
 data_file: Rock
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/SCT.md
+++ b/content/prefabs/SCT.md
@@ -3,6 +3,6 @@ layout: prefab
 title: SCT
 data_file: SCT
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Servant.md
+++ b/content/prefabs/Servant.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Servant
 data_file: Servant
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Set.md
+++ b/content/prefabs/Set.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Set
 data_file: Set
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Snapping.md
+++ b/content/prefabs/Snapping.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Snapping
 data_file: Snapping
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Snow.md
+++ b/content/prefabs/Snow.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Snow
 data_file: Snow
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Spell.md
+++ b/content/prefabs/Spell.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Spell
 data_file: Spell
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Stash.md
+++ b/content/prefabs/Stash.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Stash
 data_file: Stash
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Stat.md
+++ b/content/prefabs/Stat.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Stat
 data_file: Stat
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Station.md
+++ b/content/prefabs/Station.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Station
 data_file: Station
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Storm.md
+++ b/content/prefabs/Storm.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Storm
 data_file: Storm
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Sun.md
+++ b/content/prefabs/Sun.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Sun
 data_file: Sun
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/TM.md
+++ b/content/prefabs/TM.md
@@ -3,6 +3,6 @@ layout: prefab
 title: TM
 data_file: TM
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Tech.md
+++ b/content/prefabs/Tech.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Tech
 data_file: Tech
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Transmog.md
+++ b/content/prefabs/Transmog.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Transmog
 data_file: Transmog
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Trees.md
+++ b/content/prefabs/Trees.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Trees
 data_file: Trees
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/UC.md
+++ b/content/prefabs/UC.md
@@ -3,6 +3,6 @@ layout: prefab
 title: UC
 data_file: UC
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Undead.md
+++ b/content/prefabs/Undead.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Undead
 data_file: Undead
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Unholy.md
+++ b/content/prefabs/Unholy.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Unholy
 data_file: Unholy
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/VIB.md
+++ b/content/prefabs/VIB.md
@@ -3,6 +3,6 @@ layout: prefab
 title: VIB
 data_file: VIB
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/VM.md
+++ b/content/prefabs/VM.md
@@ -3,6 +3,6 @@ layout: prefab
 title: VM
 data_file: VM
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Vampire.md
+++ b/content/prefabs/Vampire.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Vampire
 data_file: Vampire
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Water.md
+++ b/content/prefabs/Water.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Water
 data_file: Water
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Weapon.md
+++ b/content/prefabs/Weapon.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Weapon
 data_file: Weapon
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/Wild.md
+++ b/content/prefabs/Wild.md
@@ -3,6 +3,6 @@ layout: prefab
 title: Wild
 data_file: Wild
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/ZM.md
+++ b/content/prefabs/ZM.md
@@ -3,6 +3,6 @@ layout: prefab
 title: ZM
 data_file: ZM
 parent: Prefabs
-nav_exclude: true
+has_children: true
 search_exclude: false
 ---

--- a/content/prefabs/_index.md
+++ b/content/prefabs/_index.md
@@ -3,8 +3,6 @@ title: Prefabs
 has_children: true
 ---
 
-# Prefabs
-
 Prefabs are identifers often used in commands or configurations to refer to an object, item, effect, etc.
 
 Full list here **(warning large file)**: [all prefabs](./All) also the remainder of the prefabs with fewer than 10 in a category into [remainders prefabs](./Remainders). [Vblood Prefabs by Name](./VBloodNames).


### PR DESCRIPTION
## Summary
- remove heading from Prefabs index page
- show prefab categories in sidebar by removing `nav_exclude` and marking them with `has_children`

## Testing
- `scripts/check_shortcode_syntax.sh`
- `./scripts/dev.sh build`


------
https://chatgpt.com/codex/tasks/task_e_68a6341255bc832dbf535a3d1154016c