### PR TITLE
Add components index and theme-aware listing template

### DIFF
--- a/content/components/_index.md
+++ b/content/components/_index.md
@@ -4,4 +4,3 @@ has_children: true
 ---
 
 Components are individual data structures used by V Rising's systems. Each page documents a component and how it affects the game.
-

--- a/layouts/components/list.html
+++ b/layouts/components/list.html
@@ -1,3 +1,8 @@
+{{ define "storeOutputFormat" }}{{- .Store.Set "relearnOutputFormat" "HTML" }}{{ end }}
+{{ define "main" }}
+<h1>{{ .Title }}</h1>
+{{ .Content }}
 {{ range where site.RegularPages "Section" "components" }}
   <a href="{{ .RelPermalink }}">{{ .Title }}</a><br>
+{{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary
- add components section index with short introduction
- render components list via theme-aware template

## Testing
- `scripts/check_shortcode_syntax.sh content/components/_index.md`
- `./scripts/dev.sh build` *(fails: can't evaluate field Default in type page.Sites)*

------
https://chatgpt.com/codex/tasks/task_e_68a633e64644832dac20a637b0b84d47