### PR TITLE
Fix prefab page heading

### DIFF
--- a/layouts/prefabs/single.html
+++ b/layouts/prefabs/single.html
@@ -3,7 +3,7 @@
 {{ end }}
 
 {{ define "main" }}
-<h1>{{ .Title }} Prefabs</h1>
+<h1>{{ .Title }}</h1>
 
 {{ $prefab_data := index site.Data.prefabs .Params.data_file }}
 


### PR DESCRIPTION
## Summary
- Remove redundant `Prefabs` suffix from prefab pages' main heading

## Testing
- `scripts/check_shortcode_syntax.sh`
- `./scripts/dev.sh build` *(fails: site build produces extensive warnings and was interrupted after verifying Hugo execution)*

------
https://chatgpt.com/codex/tasks/task_e_68a641238758832d837c9c66dfbb8b21