### PR TITLE
List prefabs page links

### DIFF
--- a/content/prefabs/_index.md
+++ b/content/prefabs/_index.md
@@ -5,4 +5,6 @@ has_children: true
 
 Prefabs are identifers often used in commands or configurations to refer to an object, item, effect, etc.
 
-Full list here **(warning large file)**: [all prefabs](./All) also the remainder of the prefabs with fewer than 10 in a category into [remainders prefabs](./Remainders). [Vblood Prefabs by Name](./VBloodNames).
+- [All Prefabs](./All) *(large file)*
+- [Remainders](./Remainders) – categories with fewer than 10 entries
+- [VBlood Prefabs by Name](./VBloodNames)


### PR DESCRIPTION
## Summary
- restructure Prefabs index to list major prefab link pages

## Testing
- `scripts/check_shortcode_syntax.sh`
- `./scripts/dev.sh build` *(fails: numerous warnings and heavy output; command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a66c9d78e8832d9c9df7200962be66