### PR TITLE
Handle ref shortcode link conversions

### DIFF
--- a/scripts/rewrite_root_links.py
+++ b/scripts/rewrite_root_links.py
@@ -26,6 +26,8 @@ import re
 from pathlib import Path
 
 ROOT_LINK_RE = re.compile(r"\]\(/([^\s)]+)\)")
+LINK_SHORTCODE_RE = re.compile(r"\[([^\]]+)\]\{\{<\s*(ref|relref)\s*\"([^\"]+)\"\s*>\}\}")
+SHORTCODE_RE = re.compile(r"\{\{<\s*(ref|relref)\s*\"([^\"]+)\"\s*>\}\}")
 
 
 def _strip_first_heading(text: str) -> str:
@@ -53,18 +55,37 @@ def _strip_first_heading(text: str) -> str:
     return text
 
 
+def _normalize_target(target: str) -> str:
+    path, _, anchor = target.lstrip("/").partition("#")
+    if path.endswith("/"):
+        path = f"{path.rstrip('/')}/_index.md"
+    elif not Path(path).suffix:
+        path = f"{path}.md"
+    anchor = f"#{anchor}" if anchor else ""
+    return f"{path}{anchor}"
+
+
 def rewrite_links(text: str) -> str:
     def _replace(match: re.Match[str]) -> str:
-        target = match.group(1)
-        path, _, anchor = target.partition("#")
-        if path.endswith("/"):
-            path = f"{path.rstrip('/')}/_index.md"
-        elif not Path(path).suffix:
-            path = f"{path}.md"
-        anchor = f"#{anchor}" if anchor else ""
-        return f']({{{{% relref "{path}{anchor}" %}}}})'
+        target = _normalize_target(match.group(1))
+        return f']({{{{% relref "{target}" %}}}})'
 
     return ROOT_LINK_RE.sub(_replace, text)
+
+
+def rewrite_shortcodes(text: str) -> str:
+    def _replace_link(match: re.Match[str]) -> str:
+        label, kind, target = match.groups()
+        target = _normalize_target(target)
+        return f'[{label}]({{{{% {kind} "{target}" %}}}})'
+
+    def _replace_sc(match: re.Match[str]) -> str:
+        kind, target = match.groups()
+        target = _normalize_target(target)
+        return f'{{{{% {kind} "{target}" %}}}}'
+
+    text = LINK_SHORTCODE_RE.sub(_replace_link, text)
+    return SHORTCODE_RE.sub(_replace_sc, text)
 
 
 def process_file(path: Path, repo_root: Path, log_path: Path) -> bool:
@@ -82,6 +103,7 @@ def process_file(path: Path, repo_root: Path, log_path: Path) -> bool:
 
     text = data.decode("utf-8")
     new_text = rewrite_links(text)
+    new_text = rewrite_shortcodes(new_text)
 
     rel_parts = path.relative_to(repo_root).parts
     if (

--- a/tests/test_rewrite_root_links.py
+++ b/tests/test_rewrite_root_links.py
@@ -4,28 +4,40 @@ from pathlib import Path
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
-from rewrite_root_links import rewrite_links
+from rewrite_root_links import rewrite_links, rewrite_shortcodes
 
 
 def test_rewrites_to_md():
     src = "See [link](/foo/bar)"
-    expected = 'See [link]({< relref "foo/bar.md" >})'
+    expected = 'See [link]({{% relref "foo/bar.md" %}})'
     assert rewrite_links(src) == expected
 
 
 def test_rewrites_to_md_and_preserves_anchor():
     src = "See [link](/foo/bar#section)"
-    expected = 'See [link]({< relref "foo/bar.md#section" >})'
+    expected = 'See [link]({{% relref "foo/bar.md#section" %}})'
     assert rewrite_links(src) == expected
 
 
 def test_rewrites_trailing_slash_to_index():
     src = "See [dir](/foo/bar/)"
-    expected = 'See [dir]({< relref "foo/bar/_index.md" >})'
+    expected = 'See [dir]({{% relref "foo/bar/_index.md" %}})'
     assert rewrite_links(src) == expected
 
 
 def test_rewrites_trailing_slash_to_index_and_preserves_anchor():
     src = "See [dir](/foo/bar/#section)"
-    expected = 'See [dir]({< relref "foo/bar/_index.md#section" >})'
+    expected = 'See [dir]({{% relref "foo/bar/_index.md#section" %}})'
     assert rewrite_links(src) == expected
+
+
+def test_rewrites_shortcode_in_link():
+    src = '[home]{{< ref "/foo/bar" >}}'
+    expected = '[home]({{% ref "foo/bar.md" %}})'
+    assert rewrite_shortcodes(src) == expected
+
+
+def test_rewrites_bare_shortcode():
+    src = '{{< relref "/foo/bar/" >}}'
+    expected = '{{% relref "foo/bar/_index.md" %}}'
+    assert rewrite_shortcodes(src) == expected


### PR DESCRIPTION
## Summary
- handle `[text]{{< ref|relref >}}` and standalone `{{< ref|relref >}}` shortcodes with path normalization
- call new shortcode replacement routine in rewrite_root_links
- test shortcode rewriting cases

## Testing
- `scripts/check_shortcode_syntax.sh scripts/rewrite_root_links.py tests/test_rewrite_root_links.py`
- `pytest tests/test_rewrite_root_links.py -q`
- `./scripts/dev.sh build` *(fails: numerous warning messages; build process did not complete due to extensive warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a753318aa8832db3fabf3e52a2a657