### PR TITLE
Ensure relref usage in link rewriting tests

### DIFF
--- a/scripts/rewrite_root_links.py
+++ b/scripts/rewrite_root_links.py
@@ -75,14 +75,14 @@ def rewrite_links(text: str) -> str:
 
 def rewrite_shortcodes(text: str) -> str:
     def _replace_link(match: re.Match[str]) -> str:
-        label, kind, target = match.groups()
+        label, _, target = match.groups()
         target = _normalize_target(target)
-        return f'[{label}]({{{{% {kind} "{target}" %}}}})'
+        return f'[{label}]({{{{% relref "{target}" %}}}})'
 
     def _replace_sc(match: re.Match[str]) -> str:
-        kind, target = match.groups()
+        _, target = match.groups()
         target = _normalize_target(target)
-        return f'{{{{% {kind} "{target}" %}}}}'
+        return f'{{{{% relref "{target}" %}}}}'
 
     text = LINK_SHORTCODE_RE.sub(_replace_link, text)
     return SHORTCODE_RE.sub(_replace_sc, text)

--- a/tests/test_rewrite_root_links.py
+++ b/tests/test_rewrite_root_links.py
@@ -32,8 +32,8 @@ def test_rewrites_trailing_slash_to_index_and_preserves_anchor():
 
 
 def test_rewrites_shortcode_in_link():
-    src = '[home]{{< ref "/foo/bar" >}}'
-    expected = '[home]({{% ref "foo/bar.md" %}})'
+    src = '[home]{{< relref "foo/bar" >}}'
+    expected = '[home]({{% relref "foo/bar.md" %}})'
     assert rewrite_shortcodes(src) == expected
 
 
@@ -41,3 +41,16 @@ def test_rewrites_bare_shortcode():
     src = '{{< relref "/foo/bar/" >}}'
     expected = '{{% relref "foo/bar/_index.md" %}}'
     assert rewrite_shortcodes(src) == expected
+
+
+def test_rewrites_ref_shortcode():
+    src = '{{< ref "foo/bar" >}}'
+    expected = '{{% relref "foo/bar.md" %}}'
+    assert rewrite_shortcodes(src) == expected
+
+
+def test_rewrite_links_idempotent():
+    src = "See [link](/foo/bar)"
+    once = rewrite_links(src)
+    twice = rewrite_links(once)
+    assert twice == once


### PR DESCRIPTION
## Summary
- force `rewrite_shortcodes` to emit `relref` shortcodes
- expand link rewrite tests and verify idempotency

## Testing
- `scripts/check_shortcode_syntax.sh`
- ⚠️ `./scripts/dev.sh build` (failed: could not clone submodule)
- `pytest tests/test_rewrite_root_links.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7568b5cd8832db4a5b40e364f2489