### PR TITLE
Use content basename for prefab permalinks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ ignoreLogs:
   - warning-goldmark-raw-html
 
 permalinks:
-  prefabs: "/prefabs/:filename/"
+  prefabs: "/prefabs/:contentbasename/"
 
 sitemap:
   changefreq: monthly

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -30,12 +30,12 @@ fi
 case "$action" in
   serve)
     log_file="serve.log"
-    hugo server --verbose 2>&1 | tee "$log_file"
+    hugo server --logLevel info 2>&1 | tee "$log_file"
     echo "Hugo server log stored at $log_file"
     ;;
   build)
     log_file="build.log"
-    hugo --verbose 2>&1 | tee "$log_file"
+    hugo --logLevel info 2>&1 | tee "$log_file"
     echo "Hugo build log stored at $log_file"
     ;;
   *)


### PR DESCRIPTION
## Summary
- use `:contentbasename` in prefab permalinks
- update dev script to use `--logLevel info` for Hugo

## Testing
- `scripts/check_shortcode_syntax.sh config.yaml`
- `./scripts/dev.sh build`

------
https://chatgpt.com/codex/tasks/task_e_68a7b8843184832d870e6b2d4ad37cd5