### PR TITLE
docs: use percent relref shortcode in examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Please review [AGENTS.md](AGENTS.md) for commit limits, binary file restrictions
 - Use Hugo's `relref` shortcode for internal links:
   
   ```md
-  [link text]({{< relref "path/to/page.md" >}})
+  [link text]({{% relref "path/to/page.md" %}})
   ```
 - During reviews, search for root-relative links like `[text](/path/)` and replace them with `relref`:
   

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This repository contains the source for the V Rising Modding Wiki. It is built with [Hugo](https://gohugo.io/) using the Relearn theme. Markdown content lives in the `content/` directory.
 
-## Visit the wiki: [Home]({{< relref "_index.md" >}})
+## Visit the wiki: [Home]({{% relref "_index.md" %}})
 
 ## Local development
 

--- a/editing.md
+++ b/editing.md
@@ -30,7 +30,7 @@ You can just paste images while inside the GitHub markdown editor and it will up
 Use Hugo's `relref` shortcode to link between pages:
 
 ```md
-[link text]({{< relref "path/to/page.md" >}})
+[link text]({{% relref "path/to/page.md" %}})
 ```
 
 Avoid root-relative links like `[text](/path/)`; `relref` keeps links working when pages move.


### PR DESCRIPTION
## Summary
- fix relref shortcode examples to use percent form

## Testing
- `scripts/check_shortcode_syntax.sh README.md CONTRIBUTING.md editing.md`
- `./scripts/dev.sh build` *(fails: permalink ill-formed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bd83ba94832da8a1c301e0855e2e