### PR TITLE
Add defer to DataTables scripts

### DIFF
--- a/layouts/partials/data_table_search.html
+++ b/layouts/partials/data_table_search.html
@@ -3,7 +3,7 @@
 {{ $dtJs := resources.Get "js/datatables-2.0.8.js" | resources.Minify }}
 {{ $init := resources.Get "js/dataTableSearch.js" | resources.Minify }}
 <link rel="stylesheet" href="{{ $dtCss.RelPermalink }}">
-<script src="{{ $jquery.RelPermalink }}"></script>
-<script src="{{ $dtJs.RelPermalink }}"></script>
-<script src="{{ $init.RelPermalink }}"></script>
+<script src="{{ $jquery.RelPermalink }}" defer></script>
+<script src="{{ $dtJs.RelPermalink }}" defer></script>
+<script src="{{ $init.RelPermalink }}" defer></script>
 <noscript>Table search and pagination require JavaScript. The table will display without these features if JavaScript is disabled.</noscript>


### PR DESCRIPTION
## Summary
- load jQuery, DataTables, and search helper scripts with `defer` to avoid blocking rendering
- ensure DataTables initialization waits for DOMContentLoaded

## Testing
- `scripts/check_shortcode_syntax.sh`
- `./scripts/dev.sh build` *(fails: permalink ill-formed)*

------
https://chatgpt.com/codex/tasks/task_e_68b85803f244832dacb032610c5a0b9c