### PR TITLE
Exclude large prefab listings from search

### DIFF
--- a/content/prefabs/AB.md
+++ b/content/prefabs/AB.md
@@ -4,5 +4,5 @@ title: AB
 data_file: AB
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/AI.md
+++ b/content/prefabs/AI.md
@@ -4,5 +4,5 @@ title: AI
 data_file: AI
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Ability.md
+++ b/content/prefabs/Ability.md
@@ -4,5 +4,5 @@ title: Ability
 data_file: Ability
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Aim.md
+++ b/content/prefabs/Aim.md
@@ -4,5 +4,5 @@ title: Aim
 data_file: Aim
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/All.md
+++ b/content/prefabs/All.md
@@ -4,5 +4,5 @@ title: All
 data_file: All
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Ascendancy.md
+++ b/content/prefabs/Ascendancy.md
@@ -4,5 +4,5 @@ title: Ascendancy
 data_file: Ascendancy
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/BEH.md
+++ b/content/prefabs/BEH.md
@@ -4,5 +4,5 @@ title: BEH
 data_file: BEH
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/BP.md
+++ b/content/prefabs/BP.md
@@ -4,5 +4,5 @@ title: BP
 data_file: BP
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Base.md
+++ b/content/prefabs/Base.md
@@ -4,5 +4,5 @@ title: Base
 data_file: Base
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Biome.md
+++ b/content/prefabs/Biome.md
@@ -4,5 +4,5 @@ title: Biome
 data_file: Biome
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Blood.md
+++ b/content/prefabs/Blood.md
@@ -4,5 +4,5 @@ title: Blood
 data_file: Blood
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Braziers.md
+++ b/content/prefabs/Braziers.md
@@ -4,5 +4,5 @@ title: Braziers
 data_file: Braziers
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Buff.md
+++ b/content/prefabs/Buff.md
@@ -4,5 +4,5 @@ title: Buff
 data_file: Buff
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/CHAR.md
+++ b/content/prefabs/CHAR.md
@@ -4,5 +4,5 @@ title: CHAR
 data_file: CHAR
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/CO.md
+++ b/content/prefabs/CO.md
@@ -4,5 +4,5 @@ title: CO
 data_file: CO
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Castle.md
+++ b/content/prefabs/Castle.md
@@ -4,5 +4,5 @@ title: Castle
 data_file: Castle
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Chain.md
+++ b/content/prefabs/Chain.md
@@ -4,5 +4,5 @@ title: Chain
 data_file: Chain
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Copper.md
+++ b/content/prefabs/Copper.md
@@ -4,5 +4,5 @@ title: Copper
 data_file: Copper
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Creature.md
+++ b/content/prefabs/Creature.md
@@ -4,5 +4,5 @@ title: Creature
 data_file: Creature
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Critter.md
+++ b/content/prefabs/Critter.md
@@ -4,5 +4,5 @@ title: Critter
 data_file: Critter
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Curtains.md
+++ b/content/prefabs/Curtains.md
@@ -4,5 +4,5 @@ title: Curtains
 data_file: Curtains
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Curve.md
+++ b/content/prefabs/Curve.md
@@ -4,5 +4,5 @@ title: Curve
 data_file: Curve
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/DG.md
+++ b/content/prefabs/DG.md
@@ -4,5 +4,5 @@ title: DG
 data_file: DG
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/DT.md
+++ b/content/prefabs/DT.md
@@ -4,5 +4,5 @@ title: DT
 data_file: DT
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Door.md
+++ b/content/prefabs/Door.md
@@ -4,5 +4,5 @@ title: Door
 data_file: Door
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Dye.md
+++ b/content/prefabs/Dye.md
@@ -4,5 +4,5 @@ title: Dye
 data_file: Dye
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Dynamic.md
+++ b/content/prefabs/Dynamic.md
@@ -4,5 +4,5 @@ title: Dynamic
 data_file: Dynamic
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Dynamics.md
+++ b/content/prefabs/Dynamics.md
@@ -4,5 +4,5 @@ title: Dynamics
 data_file: Dynamics
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/EH.md
+++ b/content/prefabs/EH.md
@@ -4,5 +4,5 @@ title: EH
 data_file: EH
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Ease.md
+++ b/content/prefabs/Ease.md
@@ -4,5 +4,5 @@ title: Ease
 data_file: Ease
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Elris.md
+++ b/content/prefabs/Elris.md
@@ -4,5 +4,5 @@ title: Elris
 data_file: Elris
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Equip.md
+++ b/content/prefabs/Equip.md
@@ -4,5 +4,5 @@ title: Equip
 data_file: Equip
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Faction.md
+++ b/content/prefabs/Faction.md
@@ -4,5 +4,5 @@ title: Faction
 data_file: Faction
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Fake.md
+++ b/content/prefabs/Fake.md
@@ -4,5 +4,5 @@ title: Fake
 data_file: Fake
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Garden.md
+++ b/content/prefabs/Garden.md
@@ -4,5 +4,5 @@ title: Garden
 data_file: Garden
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Gloom.md
+++ b/content/prefabs/Gloom.md
@@ -4,5 +4,5 @@ title: Gloom
 data_file: Gloom
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Gravestone.md
+++ b/content/prefabs/Gravestone.md
@@ -4,5 +4,5 @@ title: Gravestone
 data_file: Gravestone
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Graveyard.md
+++ b/content/prefabs/Graveyard.md
@@ -4,5 +4,5 @@ title: Graveyard
 data_file: Graveyard
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Ground.md
+++ b/content/prefabs/Ground.md
@@ -4,5 +4,5 @@ title: Ground
 data_file: Ground
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Illusion.md
+++ b/content/prefabs/Illusion.md
@@ -4,5 +4,5 @@ title: Illusion
 data_file: Illusion
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Iron.md
+++ b/content/prefabs/Iron.md
@@ -4,5 +4,5 @@ title: Iron
 data_file: Iron
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Item.md
+++ b/content/prefabs/Item.md
@@ -4,5 +4,5 @@ title: Item
 data_file: Item
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Journal.md
+++ b/content/prefabs/Journal.md
@@ -4,5 +4,5 @@ title: Journal
 data_file: Journal
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Map.md
+++ b/content/prefabs/Map.md
@@ -4,5 +4,5 @@ title: Map
 data_file: Map
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Micro.md
+++ b/content/prefabs/Micro.md
@@ -4,5 +4,5 @@ title: Micro
 data_file: Micro
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Milo.md
+++ b/content/prefabs/Milo.md
@@ -4,5 +4,5 @@ title: Milo
 data_file: Milo
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Music.md
+++ b/content/prefabs/Music.md
@@ -4,5 +4,5 @@ title: Music
 data_file: Music
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/NPCDeadeye.md
+++ b/content/prefabs/NPCDeadeye.md
@@ -4,5 +4,5 @@ title: NPCDeadeye
 data_file: NPCDeadeye
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/PVP.md
+++ b/content/prefabs/PVP.md
@@ -4,5 +4,5 @@ title: PVP
 data_file: PVP
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Quarry.md
+++ b/content/prefabs/Quarry.md
@@ -4,5 +4,5 @@ title: Quarry
 data_file: Quarry
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Random.md
+++ b/content/prefabs/Random.md
@@ -4,5 +4,5 @@ title: Random
 data_file: Random
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Recipe.md
+++ b/content/prefabs/Recipe.md
@@ -4,5 +4,5 @@ title: Recipe
 data_file: Recipe
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Remainders.md
+++ b/content/prefabs/Remainders.md
@@ -4,5 +4,5 @@ title: Remainders
 data_file: Remainders
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Resource.md
+++ b/content/prefabs/Resource.md
@@ -4,5 +4,5 @@ title: Resource
 data_file: Resource
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Rock.md
+++ b/content/prefabs/Rock.md
@@ -4,5 +4,5 @@ title: Rock
 data_file: Rock
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/SCT.md
+++ b/content/prefabs/SCT.md
@@ -4,5 +4,5 @@ title: SCT
 data_file: SCT
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Servant.md
+++ b/content/prefabs/Servant.md
@@ -4,5 +4,5 @@ title: Servant
 data_file: Servant
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Set.md
+++ b/content/prefabs/Set.md
@@ -4,5 +4,5 @@ title: Set
 data_file: Set
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Snapping.md
+++ b/content/prefabs/Snapping.md
@@ -4,5 +4,5 @@ title: Snapping
 data_file: Snapping
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Snow.md
+++ b/content/prefabs/Snow.md
@@ -4,5 +4,5 @@ title: Snow
 data_file: Snow
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Spell.md
+++ b/content/prefabs/Spell.md
@@ -4,5 +4,5 @@ title: Spell
 data_file: Spell
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Stash.md
+++ b/content/prefabs/Stash.md
@@ -4,5 +4,5 @@ title: Stash
 data_file: Stash
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Stat.md
+++ b/content/prefabs/Stat.md
@@ -4,5 +4,5 @@ title: Stat
 data_file: Stat
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Station.md
+++ b/content/prefabs/Station.md
@@ -4,5 +4,5 @@ title: Station
 data_file: Station
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Storm.md
+++ b/content/prefabs/Storm.md
@@ -4,5 +4,5 @@ title: Storm
 data_file: Storm
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Sun.md
+++ b/content/prefabs/Sun.md
@@ -4,5 +4,5 @@ title: Sun
 data_file: Sun
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/TM.md
+++ b/content/prefabs/TM.md
@@ -4,5 +4,5 @@ title: TM
 data_file: TM
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Tech.md
+++ b/content/prefabs/Tech.md
@@ -4,5 +4,5 @@ title: Tech
 data_file: Tech
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Transmog.md
+++ b/content/prefabs/Transmog.md
@@ -4,5 +4,5 @@ title: Transmog
 data_file: Transmog
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Trees.md
+++ b/content/prefabs/Trees.md
@@ -4,5 +4,5 @@ title: Trees
 data_file: Trees
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/UC.md
+++ b/content/prefabs/UC.md
@@ -4,5 +4,5 @@ title: UC
 data_file: UC
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Undead.md
+++ b/content/prefabs/Undead.md
@@ -4,5 +4,5 @@ title: Undead
 data_file: Undead
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Unholy.md
+++ b/content/prefabs/Unholy.md
@@ -4,5 +4,5 @@ title: Unholy
 data_file: Unholy
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/VBloodNames.md
+++ b/content/prefabs/VBloodNames.md
@@ -4,7 +4,7 @@ title: VBlood Names
 parent: Prefabs
 data_file: vblood_names
 nav_exclude: false
-search_exclude: false
+search_exclude: true
 ---
 
 <h1>{{ page.title }} Prefabs</h1>

--- a/content/prefabs/VIB.md
+++ b/content/prefabs/VIB.md
@@ -4,5 +4,5 @@ title: VIB
 data_file: VIB
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/VM.md
+++ b/content/prefabs/VM.md
@@ -4,5 +4,5 @@ title: VM
 data_file: VM
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Vampire.md
+++ b/content/prefabs/Vampire.md
@@ -4,5 +4,5 @@ title: Vampire
 data_file: Vampire
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Water.md
+++ b/content/prefabs/Water.md
@@ -4,5 +4,5 @@ title: Water
 data_file: Water
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Weapon.md
+++ b/content/prefabs/Weapon.md
@@ -4,5 +4,5 @@ title: Weapon
 data_file: Weapon
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/Wild.md
+++ b/content/prefabs/Wild.md
@@ -4,5 +4,5 @@ title: Wild
 data_file: Wild
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/ZM.md
+++ b/content/prefabs/ZM.md
@@ -4,5 +4,5 @@ title: ZM
 data_file: ZM
 parent: Prefabs
 has_children: true
-search_exclude: false
+search_exclude: true
 ---

--- a/content/prefabs/_index.md
+++ b/content/prefabs/_index.md
@@ -1,10 +1,27 @@
 ---
 title: Prefabs
 has_children: true
+search_exclude: false
 ---
 
-Prefabs are identifers often used in commands or configurations to refer to an object, item, effect, etc.
+Prefabs are identifiers often used in commands or configurations to refer to an object, item, effect, etc.
 
-- [All Prefabs](./All) *(large file)*
-- [Remainders](./Remainders) – categories with fewer than 10 entries
-- [VBlood Prefabs by Name](./VBloodNames)
+Browse common categories:
+
+- [Ability](./Ability)
+- [Castle](./Castle)
+- [Creature](./Creature)
+- [Critter](./Critter)
+- [Dye](./Dye)
+- [Dynamics](./Dynamics)
+- [Equip](./Equip)
+- [Faction](./Faction)
+- [Ground](./Ground)
+- [Item](./Item)
+- [Map](./Map)
+- [Quarry](./Quarry)
+- [Set](./Set)
+- [Transmog](./Transmog)
+- [VBlood Names](./VBloodNames)
+- [All Prefabs](./All) *(very large; excluded from search)*
+- [Remainders](./Remainders) – categories with fewer than 10 entries (excluded from search)


### PR DESCRIPTION
## Summary
- hide expansive prefab listing pages from site search
- add curated index of top prefab categories

## Testing
- `scripts/check_shortcode_syntax.sh` (fails: found disallowed angle-bracket shortcode in theme examples)
- `./scripts/dev.sh build`


------
https://chatgpt.com/codex/tasks/task_e_68b860c77a0c832dab8c332f60cb6711