### PR TITLE
Enable dynamic pagination for prefab listings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -303,4 +303,7 @@ public/
 components/
 components.yml
 
+# Generated prefab slices
+static/prefab-slices/
+
 

--- a/assets/js/dataTableSearch.js
+++ b/assets/js/dataTableSearch.js
@@ -1,35 +1,72 @@
 document.addEventListener('DOMContentLoaded', function() {
-    if (typeof $.fn.dataTable === 'undefined') {
-      console.error('DataTables is not loaded');
-      return;
-    }
-    
-    // this renders the datatable with reasonable defaults
-    $('html').each(function() {
-      $(this).addClass('dark');
-    });
-    // Add DataTable to each table
-    $('table').each(function() {
-      console.log('Processing table:', this);
-  
-      new DataTable(this, {
-        paging: true,
-        searching: true,
-        ordering: false,
-        info: true,
-        lengthChange: true,
-        pageLength: 10, // Number of rows per page
-        language: {
-          search: "Search:"
-        },
-        layout:{
-          topStart:{
-            pageLength:{
-              menu: [10, 20, 50, 100, 200]
-            }
+  if (typeof $.fn.dataTable === 'undefined') {
+    console.error('DataTables is not loaded');
+    return;
+  }
+
+  // this renders the datatable with reasonable defaults
+  $('html').each(function() {
+    $(this).addClass('dark');
+  });
+  // Add DataTable to each table
+  $('table').each(function() {
+    console.log('Processing table:', this);
+    var $table = $(this);
+    var source = $table.data('source');
+    var total = $table.data('total');
+
+    var options = {
+      paging: true,
+      searching: true,
+      ordering: false,
+      info: true,
+      lengthChange: true,
+      pageLength: 10,
+      language: {
+        search: "Search:"
+      },
+      layout:{
+        topStart:{
+          pageLength:{
+            menu: [10, 20, 50, 100, 200]
           }
         }
-      });
-    });
+      }
+    };
+
+    if (source) {
+      options.lengthChange = false;
+      options.pageLength = 100;
+      options.serverSide = true;
+      options.processing = true;
+      options.deferRender = true;
+      options.ajax = function(data, callback) {
+        var page = Math.floor(data.start / options.pageLength);
+        fetch(source + '_' + page + '.json')
+          .then(function(resp) { return resp.json(); })
+          .then(function(json) {
+            callback({
+              data: json,
+              recordsTotal: total,
+              recordsFiltered: total
+            });
+          });
+      };
+      options.columns = [
+        {
+          data: 0,
+          render: function(data, type) {
+            if (type === 'display') {
+              return '<a href="/prefabs/' + data + '"><b>' + data + '</b></a>';
+            }
+            return data;
+          }
+        },
+        { data: 1 }
+      ];
+    }
+
+    new DataTable(this, options);
   });
-  
+});
+

--- a/content/prefabs/_index.md
+++ b/content/prefabs/_index.md
@@ -23,5 +23,5 @@ Browse common categories:
 - [Set](./Set)
 - [Transmog](./Transmog)
 - [VBlood Names](./VBloodNames)
-- [All Prefabs](./All) *(very large; excluded from search)*
+- [All Prefabs](./All) *(dynamic view; excluded from search)*
 - [Remainders](./Remainders) – categories with fewer than 10 entries (excluded from search)

--- a/layouts/prefabs/single.html
+++ b/layouts/prefabs/single.html
@@ -8,6 +8,18 @@
 {{ $prefab_data := index site.Data.prefabs .Params.data_file }}
 
 {{ .Content }}
+{{ if eq .Params.data_file "All" }}
+{{ $slice_base := (printf "/prefab-slices/All") | relURL }}
+<table id="prefab-table" data-source="{{ $slice_base }}" data-total="{{ len $prefab_data }}">
+        <thead>
+                <tr>
+                        <th>Prefab</th>
+                        <th>Id</th>
+                </tr>
+        </thead>
+        <tbody></tbody>
+</table>
+{{ else }}
 <table>
         <thead>
                 <tr>
@@ -24,5 +36,6 @@
                 {{ end }}
         </tbody>
 </table>
+{{ end }}
 {{ partial "data_table_search.html" . }}
 {{ end }}

--- a/scripts/build_prefab_files.py
+++ b/scripts/build_prefab_files.py
@@ -51,6 +51,16 @@ def main() -> None:
             )
             content_path.write_text(front_matter)
 
+    # Generate paginated JSON slices for client-side loading
+    slice_dir = repo_root / "static" / "prefab-slices"
+    slice_dir.mkdir(parents=True, exist_ok=True)
+    chunk_size = 100
+    for idx in range(0, len(names), chunk_size):
+        chunk = names[idx : idx + chunk_size]
+        slice_data = [[name, prefabs[name]] for name in chunk]
+        slice_path = slice_dir / f"All_{idx // chunk_size}.json"
+        slice_path.write_text(json.dumps(slice_data))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Load the "All" prefabs listing via AJAX and paginate data slices
- Generate paginated prefab JSON slices for client-side loading
- Note dynamic prefab view in navigation and ignore generated slices

## Testing
- `scripts/check_shortcode_syntax.sh`
- `./scripts/dev.sh build` *(fails: hugo: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86484b5f0832d95a813028db76b96