### PR TITLE
chore: set canonical baseURL

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-baseURL: "/"
+baseURL: "https://wiki.vrisingmods.com/"
 relativeURLs: true
 canonifyURLs: true
 title: "V Rising Mod Wiki"


### PR DESCRIPTION
## Summary
- point `baseURL` to https://wiki.vrisingmods.com/

## Testing
- `scripts/check_shortcode_syntax.sh`
- `./scripts/dev.sh build` *(fails: cloning theme submodule requires large download and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d34d5400832da3418042e80b090e