### PR TITLE
Escape newline in OG description

### DIFF
--- a/layouts/partials/custom-header.html
+++ b/layouts/partials/custom-header.html
@@ -5,7 +5,7 @@
 </script>
 <script async defer data-domain="wiki.vrisingmods.com" src="https://traffic.dev.deca.gg/js/script.js"></script>
 
-<meta property="og:description" content="Information about mods for the game V Rising: How to setup on Windows / Linux. Developer information. How to build, debug, and publish your mods.">
+<meta property="og:description" content="Information about mods for the game V Rising: How to setup on Windows / Linux.&#10;Developer information. How to build, debug, and publish your mods.">
 <meta property="og:image" content="{{ "images/VRisingModdingLogoNew.png" | relURL }}">
 <meta property="twitter:image" content="{{ "images/VRisingModdingLogoNew.png" | relURL }}">
 


### PR DESCRIPTION
## Summary
- encode newline with HTML entity in og:description meta tag to keep line intact

## Testing
- `scripts/check_shortcode_syntax.sh`
- `./scripts/dev.sh build` *(fails: cloning submodule hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d83962bc832d8beb31bbd8e01ebe