### PR TITLE
Handle DataTable fetch errors and remove debug log

### DIFF
--- a/assets/js/dataTableSearch.js
+++ b/assets/js/dataTableSearch.js
@@ -10,7 +10,6 @@ document.addEventListener('DOMContentLoaded', function() {
   });
   // Add DataTable to each table
   $('table').each(function() {
-    console.log('Processing table:', this);
     var $table = $(this);
     var source = $table.data('source');
     var total = $table.data('total');
@@ -50,6 +49,12 @@ document.addEventListener('DOMContentLoaded', function() {
               recordsTotal: total,
               recordsFiltered: total
             });
+          })
+          .catch(function(err) {
+            console.error('Failed to load data:', err);
+            var colSpan = $table.find('thead th').length || 1;
+            $table.html('<tbody><tr><td colspan="' + colSpan + '">Failed to load data.</td></tr></tbody>');
+            callback({ data: [], recordsTotal: 0, recordsFiltered: 0 });
           });
       };
       options.columns = [


### PR DESCRIPTION
## Summary
- remove stray console log from table setup
- handle fetch errors with a fallback message

## Testing
- `scripts/check_shortcode_syntax.sh` *(fails: disallowed angle-bracket shortcodes in theme docs)*
- `./scripts/dev.sh build` *(fails: error expanding "/prefabs/:contentbasename/"; permalink ill-formed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e70887fc832d839e1295e80be741