### PR TITLE
Use Orama search adapter and tidy resources page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ ignoreLogs:
   - warning-goldmark-raw-html
 
 permalinks:
-  prefabs: "/prefabs/:contentbasename/"
+  prefabs: "/prefabs/:filename/"
 
 sitemap:
   changefreq: monthly
@@ -27,7 +27,14 @@ params:
   themeVariant: vampire
   search:
     adapter:
-      identifier: lunr
+      identifier: orama
+    index:
+      sections:
+        - dev
+        - editing
+        - prefabs
+        - systems
+        - user
   focus_shortcut_key: "k"
   aux_links:
     "V Rising Thunderstore": "https://thunderstore.io/c/v-rising/"

--- a/content/dev/resources.md
+++ b/content/dev/resources.md
@@ -1,7 +1,11 @@
-- [**KindredExtract**](https://thunderstore.io/c/v-rising/p/odjit/KindredExtract/) <img alt="KindredExtract logo" src="https://github.com/user-attachments/assets/a0e5a99d-af88-4d9d-9fee-84cc3978aeae" width="60" style="vertical-align: middle;" >
+---
+title: Mod Development Resources
+weight: 7
+---
 
-title: Mod Development Resources
-weight: 7
+- [**KindredExtract**](https://thunderstore.io/c/v-rising/p/odjit/KindredExtract/) <img alt="KindredExtract logo" src="https://github.com/user-attachments/assets/a0e5a99d-af88-4d9d-9fee-84cc3978aeae" width="60" style="vertical-align: middle;" >
+
+## Wiki Resources
 ---
 
 ## Wiki Resources


### PR DESCRIPTION
## Summary
- Switch to the lighter Orama search adapter and limit indexing to major sections
- Fix Dev Resources page front matter so the site can build

## Testing
- `scripts/check_shortcode_syntax.sh content`
- `./scripts/dev.sh build` *(fails: dynacache evictions, incomplete build)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e8c95164832db5fb8e310c143090