### PR TITLE
Use DataTables for component listing

### DIFF
--- a/layouts/components/list.html
+++ b/layouts/components/list.html
@@ -2,9 +2,19 @@
 {{ define "main" }}
 <h1>{{ .Title }}</h1>
 {{ .Content }}
-<ul>
-  {{ range where site.RegularPages "Section" "components" }}
-    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
-  {{ end }}
-</ul>
+{{ partial "data_table_search.html" . }}
+<table>
+  <thead>
+    <tr>
+      <th>Component</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{ range where site.RegularPages "Section" "components" }}
+      <tr>
+        <td><a href="{{ .RelPermalink }}">{{ .Title }}</a></td>
+      </tr>
+    {{ end }}
+  </tbody>
+</table>
 {{ end }}


### PR DESCRIPTION
## Summary
- replace unordered list with DataTables-powered table for component pages

## Testing
- `scripts/check_shortcode_syntax.sh`
- `./scripts/dev.sh build`


------
https://chatgpt.com/codex/tasks/task_e_68c1f2b2c4e8832d89a7b90eb3509846