### PR TITLE
Use self-hosted Windows runner for Hugo workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, windows]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- switch Hugo deploy workflow to run on self-hosted Windows runner

## Testing
- `scripts/check_shortcode_syntax.sh`
- `./scripts/dev.sh build` *(fails: hugo: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c59d9b9430832da536a92e350241e2