### PR TITLE
Add ability damage evidence surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "npm run generate:data && npm run validate:data && vite build && jiti scripts/prepare-pages-fallback.ts",
     "preview": "vite preview",
     "verify": "npx tsc --noEmit && node scripts/check_shortcode_syntax.js content && npm run build && npm run verify:artifact",
-    "test": "npm run test:visual-review && tsx --test src/components/layout/SiteShell.test.tsx",
+    "test": "npm run test:visual-review && npm run test:ability-damage-evidence && tsx --test src/components/layout/SiteShell.test.tsx",
     "visual:baseline": "npm run build && npm run visual:baseline:capture",
     "visual:baseline:capture": "jiti scripts/visual-review.ts baseline",
     "visual:compare": "npm run build && npm run visual:compare:capture",
@@ -29,6 +29,7 @@
     "visual:feedback": "jiti scripts/visual-feedback.ts",
     "visual:summary": "jiti scripts/visual-review-summary.ts",
     "test:visual-review": "jiti scripts/visual-review.test.ts",
+    "test:ability-damage-evidence": "tsx scripts/ability-damage-evidence.test.ts",
     "qa:accepted-broad-run": "npm run refresh:db-assets && npm run verify && npm run visual:compare",
     "qa:ingestion-readiness": "jiti scripts/qa-ingestion-readiness.ts",
     "qa:spawn-readiness": "jiti scripts/qa-spawn-readiness.ts"

--- a/scripts/ability-damage-evidence.test.ts
+++ b/scripts/ability-damage-evidence.test.ts
@@ -237,3 +237,80 @@ test("does not resolve singleton damage tokens when any graph damage evidence la
   assert.equal(result.runtimeDamageEvidence.length, 2);
   assert.equal(result.textVariableValues, undefined);
 });
+
+test("preserves every damage evidence entry for the same prefab", () => {
+  const duplicateDamageEvidence = parseServerDamageEvidence({
+    entries: [
+      {
+        key: "DealDamageOnGameplayEvent:1002",
+        identity: { prefabGuid: 1002, prefabName: "AB_Test_Projectile" },
+        quality: { interpretationStatus: "raw-unverified" },
+        rawFields: { Parameters: { RawDamagePercent: 0.8, RawDamageValue: 0 } }
+      },
+      {
+        key: "DealDamageOnGameplayEvent:1010",
+        identity: { prefabGuid: 1002, prefabName: "AB_Test_Projectile" },
+        quality: { interpretationStatus: "raw-unverified" },
+        rawFields: { Parameters: { RawDamagePercent: 1.4, RawDamageValue: 0 } }
+      }
+    ]
+  });
+  const prefabs = new Map<string, AbilityDamagePrefabNode>([
+    [
+      "AB_Test_DuplicateEvidence_AbilityGroup",
+      prefab(
+        "AB_Test_DuplicateEvidence_AbilityGroup",
+        1011,
+        new Map([["ProjectM.AbilityGroupStartAbilitiesBuffer", component({}, [{ PrefabGUID: "AB_Test_Projectile PrefabGuid(1002)" }])]])
+      )
+    ],
+    ["AB_Test_Projectile", prefab("AB_Test_Projectile", 1002, new Map())]
+  ]);
+
+  const result = buildAbilityDamageEvidence({
+    abilityPrefab: "AB_Test_DuplicateEvidence_AbilityGroup",
+    abilityCategories: ["Player Usable"],
+    description: "Deals {damage} damage.",
+    existingTextVariableValues: undefined,
+    walker: createAbilityPrefabGraphWalker({ prefabs }),
+    damageEvidence: duplicateDamageEvidence
+  });
+
+  assert.equal(result.runtimeDamageEvidence.length, 2);
+  assert.deepEqual(
+    result.runtimeDamageEvidence.map((entry) => entry.sourceRef),
+    [
+      "data/enrichment/server-ecs-component-evidence.json#DealDamageOnGameplayEvent:1002",
+      "data/enrichment/server-ecs-component-evidence.json#DealDamageOnGameplayEvent:1010"
+    ]
+  );
+  assert.equal(result.textVariableValues, undefined);
+});
+
+test("does not auto-resolve absorb, reduction, or factor-style damage tokens", () => {
+  const prefabs = new Map<string, AbilityDamagePrefabNode>([
+    [
+      "AB_Test_DamageAbsorb_AbilityGroup",
+      prefab(
+        "AB_Test_DamageAbsorb_AbilityGroup",
+        1012,
+        new Map([["ProjectM.AbilityGroupStartAbilitiesBuffer", component({}, [{ PrefabGUID: "AB_Test_Area PrefabGuid(1006)" }])]])
+      )
+    ],
+    ["AB_Test_Area", prefab("AB_Test_Area", 1006, new Map())]
+  ]);
+
+  for (const description of ["Absorbs {damageabsorb} incoming damage.", "Reduces incoming hits by {damagereduction}.", "Scales by {damagefactor}."]) {
+    const result = buildAbilityDamageEvidence({
+      abilityPrefab: "AB_Test_DamageAbsorb_AbilityGroup",
+      abilityCategories: ["Player Usable"],
+      description,
+      existingTextVariableValues: undefined,
+      walker: createAbilityPrefabGraphWalker({ prefabs }),
+      damageEvidence
+    });
+
+    assert.equal(result.runtimeDamageEvidence.length, 1);
+    assert.equal(result.textVariableValues, undefined);
+  }
+});

--- a/scripts/ability-damage-evidence.test.ts
+++ b/scripts/ability-damage-evidence.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildAbilityDamageEvidence,
+  createAbilityPrefabGraphWalker,
+  parseServerDamageEvidence,
+  type AbilityDamagePrefabNode
+} from "./ability-damage-evidence";
+import type { TextVariableResolutionMap } from "../src/lib/textVariables";
+
+function component(fields: Record<string, string> = {}, entries: Array<Record<string, string>> = []) {
+  return { name: "TestComponent", fields, entries };
+}
+
+function prefab(prefabName: string, guid: number, components: AbilityDamagePrefabNode["components"]): AbilityDamagePrefabNode {
+  return { prefabName, guid, components };
+}
+
+const damageEvidence = parseServerDamageEvidence({
+  entries: [
+    {
+      key: "DealDamageOnGameplayEvent:1002",
+      identity: { prefabGuid: 1002, prefabName: "AB_Test_Projectile" },
+      quality: { interpretationStatus: "raw-unverified" },
+      rawFields: {
+        Parameters: {
+          RawDamagePercent: 0.8,
+          RawDamageValue: 0,
+          MainFactor: 1,
+          ResourceModifier: 1,
+          StaggerFactor: 0,
+          DealDamageFlags: 1065353216,
+          MainType: "1065353216"
+        },
+        DamageModifierPerHit: 0,
+        MultiplyMainFactorWithStacks: false
+      }
+    },
+    {
+      key: "DealDamageOnGameplayEvent:1004",
+      identity: { prefabGuid: 1004, prefabName: "AB_Test_ZeroDamage_Hit" },
+      quality: { interpretationStatus: "raw-unverified" },
+      rawFields: { Parameters: { RawDamagePercent: 0, RawDamageValue: 0 } }
+    },
+    {
+      key: "DealDamageOnGameplayEvent:1006",
+      identity: { prefabGuid: 1006, prefabName: "AB_Test_Area" },
+      quality: { interpretationStatus: "raw-unverified" },
+      rawFields: { Parameters: { RawDamagePercent: 1.2, RawDamageValue: 0 } }
+    },
+    {
+      key: "DealDamageOnGameplayEvent:1009",
+      identity: { prefabGuid: 1009, prefabName: "AB_Test_MissingPercent" },
+      quality: { interpretationStatus: "raw-unverified" },
+      rawFields: { Parameters: { RawDamageValue: 0 } }
+    }
+  ]
+});
+
+test("walks ability prefab references within bounded effect prefixes", () => {
+  const prefabs = new Map<string, AbilityDamagePrefabNode>([
+    [
+      "AB_Test_AbilityGroup",
+      prefab(
+        "AB_Test_AbilityGroup",
+        1000,
+        new Map([
+          [
+            "ProjectM.AbilityGroupStartAbilitiesBuffer",
+            component({}, [{ PrefabGUID: "AB_Test_Cast PrefabGuid(1001)" }, { PrefabGUID: "Item_ShouldNotWalk PrefabGuid(9000)" }])
+          ]
+        ])
+      )
+    ],
+    [
+      "AB_Test_Cast",
+      prefab("AB_Test_Cast", 1001, new Map([["ProjectM.AbilitySpawnPrefabOnCast", component({ SpawnPrefab: "AB_Test_Projectile PrefabGuid(1002)" })]]))
+    ],
+    ["AB_Test_Projectile", prefab("AB_Test_Projectile", 1002, new Map())]
+  ]);
+
+  const walker = createAbilityPrefabGraphWalker({ prefabs, maxDepth: 5, maxNodes: 80 });
+  const walked = walker.walk("AB_Test_AbilityGroup");
+
+  assert.deepEqual(
+    walked.map((entry) => entry.prefab),
+    ["AB_Test_AbilityGroup", "AB_Test_Cast", "AB_Test_Projectile"]
+  );
+});
+
+test("resolves a single unresolved damage token when graph evidence has one positive raw percent", () => {
+  const prefabs = new Map<string, AbilityDamagePrefabNode>([
+    [
+      "AB_Test_AbilityGroup",
+      prefab(
+        "AB_Test_AbilityGroup",
+        1000,
+        new Map([["ProjectM.AbilityGroupStartAbilitiesBuffer", component({}, [{ PrefabGUID: "AB_Test_Projectile PrefabGuid(1002)" }])]])
+      )
+    ],
+    ["AB_Test_Projectile", prefab("AB_Test_Projectile", 1002, new Map())]
+  ]);
+
+  const result = buildAbilityDamageEvidence({
+    abilityPrefab: "AB_Test_AbilityGroup",
+    abilityCategories: ["Player Usable", "Spell"],
+    description: "Launches a bolt dealing {damage} magic damage.",
+    existingTextVariableValues: undefined,
+    walker: createAbilityPrefabGraphWalker({ prefabs }),
+    damageEvidence
+  });
+
+  assert.equal(result.runtimeDamageEvidence.length, 1);
+  assert.deepEqual(result.textVariableValues, {
+    damage: {
+      value: "80%",
+      sourceKind: "server-damage-evidence",
+      sourceRef: "data/enrichment/server-ecs-component-evidence.json#DealDamageOnGameplayEvent:1002",
+      sourceGuid: "1002",
+      sourcePrefab: "AB_Test_Projectile"
+    }
+  } satisfies TextVariableResolutionMap);
+});
+
+test("does not resolve singleton damage tokens from zero raw percent evidence", () => {
+  const prefabs = new Map<string, AbilityDamagePrefabNode>([
+    [
+      "AB_Test_ZeroDamage_AbilityGroup",
+      prefab(
+        "AB_Test_ZeroDamage_AbilityGroup",
+        1003,
+        new Map([["ProjectM.AbilityGroupStartAbilitiesBuffer", component({}, [{ PrefabGUID: "AB_Test_ZeroDamage_Hit PrefabGuid(1004)" }])]])
+      )
+    ],
+    ["AB_Test_ZeroDamage_Hit", prefab("AB_Test_ZeroDamage_Hit", 1004, new Map())]
+  ]);
+
+  const result = buildAbilityDamageEvidence({
+    abilityPrefab: "AB_Test_ZeroDamage_AbilityGroup",
+    abilityCategories: ["Player Usable"],
+    description: "Deals {damage} damage.",
+    existingTextVariableValues: undefined,
+    walker: createAbilityPrefabGraphWalker({ prefabs }),
+    damageEvidence
+  });
+
+  assert.equal(result.runtimeDamageEvidence.length, 1);
+  assert.equal(result.textVariableValues, undefined);
+});
+
+test("does not resolve damage tokens when graph evidence has multiple positive raw percents", () => {
+  const prefabs = new Map<string, AbilityDamagePrefabNode>([
+    [
+      "AB_Test_MultiPercent_AbilityGroup",
+      prefab(
+        "AB_Test_MultiPercent_AbilityGroup",
+        1005,
+        new Map([
+          [
+            "ProjectM.AbilityGroupStartAbilitiesBuffer",
+            component({}, [{ PrefabGUID: "AB_Test_Projectile PrefabGuid(1002)" }, { PrefabGUID: "AB_Test_Area PrefabGuid(1006)" }])
+          ]
+        ])
+      )
+    ],
+    ["AB_Test_Projectile", prefab("AB_Test_Projectile", 1002, new Map())],
+    ["AB_Test_Area", prefab("AB_Test_Area", 1006, new Map())]
+  ]);
+
+  const result = buildAbilityDamageEvidence({
+    abilityPrefab: "AB_Test_MultiPercent_AbilityGroup",
+    abilityCategories: ["Player Usable"],
+    description: "Deals {damage} damage.",
+    existingTextVariableValues: undefined,
+    walker: createAbilityPrefabGraphWalker({ prefabs }),
+    damageEvidence
+  });
+
+  assert.equal(result.runtimeDamageEvidence.length, 2);
+  assert.equal(result.textVariableValues, undefined);
+});
+
+test("does not resolve multi-token damage text even when graph evidence is present", () => {
+  const prefabs = new Map<string, AbilityDamagePrefabNode>([
+    [
+      "AB_Test_MultiToken_AbilityGroup",
+      prefab(
+        "AB_Test_MultiToken_AbilityGroup",
+        1007,
+        new Map([["ProjectM.AbilityGroupStartAbilitiesBuffer", component({}, [{ PrefabGUID: "AB_Test_Projectile PrefabGuid(1002)" }])]])
+      )
+    ],
+    ["AB_Test_Projectile", prefab("AB_Test_Projectile", 1002, new Map())]
+  ]);
+
+  const result = buildAbilityDamageEvidence({
+    abilityPrefab: "AB_Test_MultiToken_AbilityGroup",
+    abilityCategories: ["Player Usable"],
+    description: "Deals {damage} damage and {bonusdamage} bonus damage.",
+    existingTextVariableValues: undefined,
+    walker: createAbilityPrefabGraphWalker({ prefabs }),
+    damageEvidence
+  });
+
+  assert.equal(result.runtimeDamageEvidence.length, 1);
+  assert.equal(result.textVariableValues, undefined);
+});
+
+test("does not resolve singleton damage tokens when any graph damage evidence lacks a raw percent", () => {
+  const prefabs = new Map<string, AbilityDamagePrefabNode>([
+    [
+      "AB_Test_MissingPercent_AbilityGroup",
+      prefab(
+        "AB_Test_MissingPercent_AbilityGroup",
+        1008,
+        new Map([
+          [
+            "ProjectM.AbilityGroupStartAbilitiesBuffer",
+            component({}, [{ PrefabGUID: "AB_Test_Projectile PrefabGuid(1002)" }, { PrefabGUID: "AB_Test_MissingPercent PrefabGuid(1009)" }])
+          ]
+        ])
+      )
+    ],
+    ["AB_Test_Projectile", prefab("AB_Test_Projectile", 1002, new Map())],
+    ["AB_Test_MissingPercent", prefab("AB_Test_MissingPercent", 1009, new Map())]
+  ]);
+
+  const result = buildAbilityDamageEvidence({
+    abilityPrefab: "AB_Test_MissingPercent_AbilityGroup",
+    abilityCategories: ["Player Usable"],
+    description: "Deals {damage} damage.",
+    existingTextVariableValues: undefined,
+    walker: createAbilityPrefabGraphWalker({ prefabs }),
+    damageEvidence
+  });
+
+  assert.equal(result.runtimeDamageEvidence.length, 2);
+  assert.equal(result.textVariableValues, undefined);
+});

--- a/scripts/ability-damage-evidence.ts
+++ b/scripts/ability-damage-evidence.ts
@@ -60,7 +60,7 @@ export interface AbilityDamageBuildOptions {
   description: string;
   existingTextVariableValues?: TextVariableResolutionMap;
   walker: AbilityPrefabGraphWalker;
-  damageEvidence: Map<string, ServerDamageEvidence>;
+  damageEvidence: Map<string, ServerDamageEvidence[]>;
 }
 
 const allowedGraphPrefabPattern = /^(AB_|Buff_|Frost_|Illusion_|Unholy_|Storm_|Chaos_|SpellMod_)/;
@@ -179,9 +179,9 @@ export function createAbilityPrefabGraphWalker(options: {
   };
 }
 
-export function parseServerDamageEvidence(snapshot: unknown): Map<string, ServerDamageEvidence> {
+export function parseServerDamageEvidence(snapshot: unknown): Map<string, ServerDamageEvidence[]> {
   const entries = Array.isArray(toRecord(snapshot)?.entries) ? (toRecord(snapshot)?.entries as unknown[]) : [];
-  const byPrefab = new Map<string, ServerDamageEvidence>();
+  const byPrefab = new Map<string, ServerDamageEvidence[]>();
 
   for (const value of entries) {
     const entry = toRecord(value);
@@ -194,13 +194,15 @@ export function parseServerDamageEvidence(snapshot: unknown): Map<string, Server
       continue;
     }
 
-    byPrefab.set(prefabName, {
+    const prefabEntries = byPrefab.get(prefabName) ?? [];
+    prefabEntries.push({
       key,
       prefabName,
       prefabGuid: toNumberValue(identity?.prefabGuid) ?? null,
       interpretationStatus: toStringValue(quality?.interpretationStatus),
       rawFields
     });
+    byPrefab.set(prefabName, prefabEntries);
   }
 
   return byPrefab;
@@ -229,8 +231,15 @@ function toRuntimeDamageEvidence(walked: AbilityPrefabGraphEntry, evidence: Serv
   };
 }
 
+function isDamageOutputToken(token: string): boolean {
+  const normalized = normalizeTextVariableName(token);
+  const looksLikeOutputDamage = /(^damage\d*$|damage\d*$)/.test(normalized);
+  const looksLikeMitigation = /(absorb|absorbed|reduction|reduce|reduced|mitigation|resist|resistance|factor|modifier|taken|received)/.test(normalized);
+  return looksLikeOutputDamage && !looksLikeMitigation;
+}
+
 function getDamageTokens(description: string): string[] {
-  return extractTextVariables(description).filter((token) => normalizeTextVariableName(token).includes("damage"));
+  return extractTextVariables(description).filter(isDamageOutputToken);
 }
 
 function resolveSingletonDamageToken(options: {
@@ -281,11 +290,7 @@ export function buildAbilityDamageEvidence(options: AbilityDamageBuildOptions): 
 } {
   const runtimeDamageEvidence = options.walker
     .walk(options.abilityPrefab)
-    .map((walked) => {
-      const evidence = options.damageEvidence.get(walked.prefab);
-      return evidence ? toRuntimeDamageEvidence(walked, evidence) : null;
-    })
-    .filter((entry): entry is RuntimeDamageEvidence => entry !== null);
+    .flatMap((walked) => (options.damageEvidence.get(walked.prefab) ?? []).map((evidence) => toRuntimeDamageEvidence(walked, evidence)));
   const singletonTextVariableValues = resolveSingletonDamageToken({
     abilityCategories: options.abilityCategories,
     description: options.description,

--- a/scripts/ability-damage-evidence.ts
+++ b/scripts/ability-damage-evidence.ts
@@ -1,0 +1,304 @@
+import {
+  extractTextVariables,
+  getTextVariableResolution,
+  normalizeTextVariableName,
+  type TextVariableResolution,
+  type TextVariableResolutionMap
+} from "../src/lib/textVariables";
+
+export interface AbilityDamageParsedComponent {
+  name: string;
+  fields: Record<string, string>;
+  entries: Array<Record<string, string>>;
+}
+
+export interface AbilityDamagePrefabNode {
+  prefabName: string;
+  guid: number | null;
+  components: Map<string, AbilityDamageParsedComponent>;
+}
+
+export interface AbilityPrefabGraphEntry {
+  prefab: string;
+  guid: number | null;
+  depth: number;
+}
+
+export interface RuntimeDamageEvidence {
+  sourceKind: "server-damage-evidence";
+  sourceRef: string;
+  sourcePrefab: string;
+  sourceGuid: number | null;
+  graphDepth: number;
+  interpretationStatus?: string;
+  RawDamagePercent?: number;
+  RawDamageValue?: number;
+  MainFactor?: number;
+  ResourceModifier?: number;
+  StaggerFactor?: number;
+  DamageModifierPerHit?: number;
+  MultiplyMainFactorWithStacks?: boolean;
+  DealDamageFlags?: number;
+  MainType?: string;
+}
+
+export interface ServerDamageEvidence {
+  key: string;
+  prefabName: string;
+  prefabGuid: number | null;
+  interpretationStatus?: string;
+  rawFields: Record<string, unknown>;
+}
+
+export interface AbilityPrefabGraphWalker {
+  walk(startPrefab: string): AbilityPrefabGraphEntry[];
+}
+
+export interface AbilityDamageBuildOptions {
+  abilityPrefab: string;
+  abilityCategories: string[];
+  description: string;
+  existingTextVariableValues?: TextVariableResolutionMap;
+  walker: AbilityPrefabGraphWalker;
+  damageEvidence: Map<string, ServerDamageEvidence>;
+}
+
+const allowedGraphPrefabPattern = /^(AB_|Buff_|Frost_|Illusion_|Unholy_|Storm_|Chaos_|SpellMod_)/;
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function toStringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function toNumberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? value.toString() : value.toFixed(2).replace(/\.?0+$/, "");
+}
+
+function formatRawDamagePercent(value: number): string {
+  return `${formatNumber(value * 100)}%`;
+}
+
+function parsePrefabReference(value: string | undefined): { prefab: string; guid: number | null } | null {
+  if (!value) {
+    return null;
+  }
+
+  const match = value.match(/([A-Za-z0-9_]+)\s+PrefabGuid\((-?\d+)\)/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    prefab: match[1],
+    guid: Number(match[2])
+  };
+}
+
+function getComponentPrefabReferences(component: AbilityDamageParsedComponent): Array<{ prefab: string; guid: number | null }> {
+  const refs: Array<{ prefab: string; guid: number | null }> = [];
+  const values = [...Object.values(component.fields), ...component.entries.flatMap((entry) => Object.values(entry))];
+
+  for (const value of values) {
+    const ref = parsePrefabReference(value);
+    if (ref && allowedGraphPrefabPattern.test(ref.prefab)) {
+      refs.push(ref);
+    }
+  }
+
+  return refs;
+}
+
+export function createAbilityPrefabGraphWalker(options: {
+  prefabs: Map<string, AbilityDamagePrefabNode>;
+  maxDepth?: number;
+  maxNodes?: number;
+}): AbilityPrefabGraphWalker {
+  const maxDepth = options.maxDepth ?? 5;
+  const maxNodes = options.maxNodes ?? 80;
+  const refCache = new Map<string, Array<{ prefab: string; guid: number | null }>>();
+
+  const refsForPrefab = (prefabName: string): Array<{ prefab: string; guid: number | null }> => {
+    const cached = refCache.get(prefabName);
+    if (cached) {
+      return cached;
+    }
+
+    const node = options.prefabs.get(prefabName);
+    if (!node) {
+      refCache.set(prefabName, []);
+      return [];
+    }
+
+    const refs = new Map<string, { prefab: string; guid: number | null }>();
+    for (const component of node.components.values()) {
+      for (const ref of getComponentPrefabReferences(component)) {
+        if (options.prefabs.has(ref.prefab) && !refs.has(ref.prefab)) {
+          refs.set(ref.prefab, ref);
+        }
+      }
+    }
+
+    const values = [...refs.values()];
+    refCache.set(prefabName, values);
+    return values;
+  };
+
+  return {
+    walk(startPrefab: string): AbilityPrefabGraphEntry[] {
+      const seen = new Map<string, AbilityPrefabGraphEntry>();
+      const queue: AbilityPrefabGraphEntry[] = [{ prefab: startPrefab, guid: options.prefabs.get(startPrefab)?.guid ?? null, depth: 0 }];
+
+      for (let index = 0; index < queue.length && seen.size < maxNodes; index += 1) {
+        const current = queue[index];
+        const node = options.prefabs.get(current.prefab);
+        if (!node || seen.has(current.prefab)) {
+          continue;
+        }
+
+        seen.set(current.prefab, { prefab: current.prefab, guid: node.guid, depth: current.depth });
+        if (current.depth >= maxDepth) {
+          continue;
+        }
+
+        for (const ref of refsForPrefab(current.prefab)) {
+          if (!seen.has(ref.prefab)) {
+            queue.push({ prefab: ref.prefab, guid: ref.guid, depth: current.depth + 1 });
+          }
+        }
+      }
+
+      return [...seen.values()];
+    }
+  };
+}
+
+export function parseServerDamageEvidence(snapshot: unknown): Map<string, ServerDamageEvidence> {
+  const entries = Array.isArray(toRecord(snapshot)?.entries) ? (toRecord(snapshot)?.entries as unknown[]) : [];
+  const byPrefab = new Map<string, ServerDamageEvidence>();
+
+  for (const value of entries) {
+    const entry = toRecord(value);
+    const identity = toRecord(entry?.identity);
+    const rawFields = toRecord(entry?.rawFields);
+    const quality = toRecord(entry?.quality);
+    const prefabName = toStringValue(identity?.prefabName);
+    const key = toStringValue(entry?.key);
+    if (!entry || !rawFields || !prefabName || !key || !key.startsWith("DealDamageOnGameplayEvent:")) {
+      continue;
+    }
+
+    byPrefab.set(prefabName, {
+      key,
+      prefabName,
+      prefabGuid: toNumberValue(identity?.prefabGuid) ?? null,
+      interpretationStatus: toStringValue(quality?.interpretationStatus),
+      rawFields
+    });
+  }
+
+  return byPrefab;
+}
+
+function toRuntimeDamageEvidence(walked: AbilityPrefabGraphEntry, evidence: ServerDamageEvidence): RuntimeDamageEvidence {
+  const parameters = toRecord(evidence.rawFields.Parameters);
+  return {
+    sourceKind: "server-damage-evidence",
+    sourceRef: `data/enrichment/server-ecs-component-evidence.json#${evidence.key}`,
+    sourcePrefab: evidence.prefabName,
+    sourceGuid: evidence.prefabGuid,
+    graphDepth: walked.depth,
+    ...(evidence.interpretationStatus ? { interpretationStatus: evidence.interpretationStatus } : {}),
+    ...(toNumberValue(parameters?.RawDamagePercent) !== undefined ? { RawDamagePercent: toNumberValue(parameters?.RawDamagePercent) } : {}),
+    ...(toNumberValue(parameters?.RawDamageValue) !== undefined ? { RawDamageValue: toNumberValue(parameters?.RawDamageValue) } : {}),
+    ...(toNumberValue(parameters?.MainFactor) !== undefined ? { MainFactor: toNumberValue(parameters?.MainFactor) } : {}),
+    ...(toNumberValue(parameters?.ResourceModifier) !== undefined ? { ResourceModifier: toNumberValue(parameters?.ResourceModifier) } : {}),
+    ...(toNumberValue(parameters?.StaggerFactor) !== undefined ? { StaggerFactor: toNumberValue(parameters?.StaggerFactor) } : {}),
+    ...(toNumberValue(evidence.rawFields.DamageModifierPerHit) !== undefined ? { DamageModifierPerHit: toNumberValue(evidence.rawFields.DamageModifierPerHit) } : {}),
+    ...(typeof evidence.rawFields.MultiplyMainFactorWithStacks === "boolean"
+      ? { MultiplyMainFactorWithStacks: evidence.rawFields.MultiplyMainFactorWithStacks }
+      : {}),
+    ...(toNumberValue(parameters?.DealDamageFlags) !== undefined ? { DealDamageFlags: toNumberValue(parameters?.DealDamageFlags) } : {}),
+    ...(toStringValue(parameters?.MainType) ? { MainType: toStringValue(parameters?.MainType) } : {})
+  };
+}
+
+function getDamageTokens(description: string): string[] {
+  return extractTextVariables(description).filter((token) => normalizeTextVariableName(token).includes("damage"));
+}
+
+function resolveSingletonDamageToken(options: {
+  abilityCategories: string[];
+  description: string;
+  existingTextVariableValues?: TextVariableResolutionMap;
+  runtimeDamageEvidence: RuntimeDamageEvidence[];
+}): TextVariableResolutionMap | undefined {
+  if (!options.abilityCategories.includes("Player Usable")) {
+    return undefined;
+  }
+
+  const damageTokens = getDamageTokens(options.description);
+  if (damageTokens.length !== 1 || getTextVariableResolution(options.existingTextVariableValues, damageTokens[0])) {
+    return undefined;
+  }
+
+  const rawPercents = options.runtimeDamageEvidence.map((entry) => entry.RawDamagePercent).filter((value): value is number => typeof value === "number");
+  const uniquePercents = [...new Set(rawPercents)];
+  if (
+    options.runtimeDamageEvidence.length === 0 ||
+    rawPercents.length !== options.runtimeDamageEvidence.length ||
+    uniquePercents.length !== 1 ||
+    uniquePercents[0] <= 0
+  ) {
+    return undefined;
+  }
+
+  const representativeEvidence = options.runtimeDamageEvidence.find((entry) => entry.RawDamagePercent === uniquePercents[0]);
+  if (!representativeEvidence) {
+    return undefined;
+  }
+
+  const resolution: TextVariableResolution = {
+    value: formatRawDamagePercent(uniquePercents[0]),
+    sourceKind: "server-damage-evidence",
+    sourceRef: representativeEvidence.sourceRef,
+    ...(representativeEvidence.sourceGuid !== null ? { sourceGuid: String(representativeEvidence.sourceGuid) } : {}),
+    sourcePrefab: representativeEvidence.sourcePrefab
+  };
+
+  return { [damageTokens[0]]: resolution };
+}
+
+export function buildAbilityDamageEvidence(options: AbilityDamageBuildOptions): {
+  runtimeDamageEvidence: RuntimeDamageEvidence[];
+  textVariableValues?: TextVariableResolutionMap;
+} {
+  const runtimeDamageEvidence = options.walker
+    .walk(options.abilityPrefab)
+    .map((walked) => {
+      const evidence = options.damageEvidence.get(walked.prefab);
+      return evidence ? toRuntimeDamageEvidence(walked, evidence) : null;
+    })
+    .filter((entry): entry is RuntimeDamageEvidence => entry !== null);
+  const singletonTextVariableValues = resolveSingletonDamageToken({
+    abilityCategories: options.abilityCategories,
+    description: options.description,
+    existingTextVariableValues: options.existingTextVariableValues,
+    runtimeDamageEvidence
+  });
+  const textVariableValues =
+    singletonTextVariableValues && options.existingTextVariableValues
+      ? { ...options.existingTextVariableValues, ...singletonTextVariableValues }
+      : singletonTextVariableValues ?? options.existingTextVariableValues;
+
+  return {
+    runtimeDamageEvidence,
+    ...(textVariableValues ? { textVariableValues } : {})
+  };
+}

--- a/scripts/build-db-index.ts
+++ b/scripts/build-db-index.ts
@@ -381,7 +381,7 @@ interface BuildContext {
   localizedNamesByGuid: Map<number, string>;
   abilityCatalogByPrefab: Map<string, AbilityCatalogEntry>;
   abilityTooltipByPrefab: Map<string, AbilityTooltipMapEntry>;
-  serverDamageByPrefab: Map<string, ServerDamageEvidence>;
+  serverDamageByPrefab: Map<string, ServerDamageEvidence[]>;
   itemIconByPrefab: Map<string, ItemIconMapEntry>;
   itemDescriptionByPrefab: Map<string, ItemDescriptionMapEntry>;
   recipeLinkByPrefab: Map<string, RecipeLinkMapEntry>;

--- a/scripts/build-db-index.ts
+++ b/scripts/build-db-index.ts
@@ -2,6 +2,15 @@ import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isNpcDisplayCandidateDoc, isNpcDisplayRelatedCategory } from "./npc-display-classification";
+import {
+  buildAbilityDamageEvidence,
+  createAbilityPrefabGraphWalker,
+  parseServerDamageEvidence,
+  type AbilityDamagePrefabNode,
+  type AbilityPrefabGraphWalker,
+  type RuntimeDamageEvidence,
+  type ServerDamageEvidence
+} from "./ability-damage-evidence";
 import { slugFromRelativePath } from "../src/lib/slug";
 import {
   filterTextVariableResolutionsForText,
@@ -139,6 +148,7 @@ interface IndexEntry {
   path: string;
   tags?: string[];
   textVariableValues?: TextVariableResolutionMap;
+  runtimeDamageEvidence?: RuntimeDamageEvidence[];
 }
 
 interface RawEntity {
@@ -371,6 +381,7 @@ interface BuildContext {
   localizedNamesByGuid: Map<number, string>;
   abilityCatalogByPrefab: Map<string, AbilityCatalogEntry>;
   abilityTooltipByPrefab: Map<string, AbilityTooltipMapEntry>;
+  serverDamageByPrefab: Map<string, ServerDamageEvidence>;
   itemIconByPrefab: Map<string, ItemIconMapEntry>;
   itemDescriptionByPrefab: Map<string, ItemDescriptionMapEntry>;
   recipeLinkByPrefab: Map<string, RecipeLinkMapEntry>;
@@ -1523,11 +1534,12 @@ function parseNpcClassificationMap(snapshot: Record<string, unknown> | null): Ma
 
 async function loadBuildContext(repoRoot: string): Promise<BuildContext> {
   const enrichmentDir = path.join(repoRoot, "data", "enrichment");
-  const [localizedSnapshot, abilityCatalogSnapshot, abilityTooltipSnapshot, itemIconSnapshot, itemDescriptionSnapshot, recipeLinkSnapshot, npcClassificationSnapshot, npcDisplaySnapshot, workstationDisplaySnapshot, blueprintDisplaySnapshot, questDisplaySnapshot, buffDisplaySnapshot, itemsetDisplaySnapshot] =
+  const [localizedSnapshot, abilityCatalogSnapshot, abilityTooltipSnapshot, serverDamageEvidenceSnapshot, itemIconSnapshot, itemDescriptionSnapshot, recipeLinkSnapshot, npcClassificationSnapshot, npcDisplaySnapshot, workstationDisplaySnapshot, blueprintDisplaySnapshot, questDisplaySnapshot, buffDisplaySnapshot, itemsetDisplaySnapshot] =
     await Promise.all([
       readJsonIfExists<LocalizedNameSnapshot>(path.join(enrichmentDir, "prefab-localization.json")),
       readJsonIfExists<AbilityCatalogSnapshot>(path.join(enrichmentDir, "ability-catalog.json")),
       readJsonIfExists<Record<string, unknown>>(path.join(enrichmentDir, "ability-tooltip-map.json")),
+      readJsonIfExists<unknown>(path.join(enrichmentDir, "server-ecs-component-evidence.json")),
       readJsonIfExists<Record<string, unknown>>(path.join(enrichmentDir, "item-icon-map.json")),
       readJsonIfExists<Record<string, unknown>>(path.join(enrichmentDir, "item-description-map.json")),
       readJsonIfExists<Record<string, unknown>>(path.join(enrichmentDir, "recipe-link-map.json")),
@@ -1588,6 +1600,7 @@ async function loadBuildContext(repoRoot: string): Promise<BuildContext> {
       })
       .filter((entry): entry is readonly [string, AbilityTooltipMapEntry] => Boolean(entry))
   );
+  const serverDamageByPrefab = parseServerDamageEvidence(serverDamageEvidenceSnapshot);
 
   const itemIconByPrefab = new Map<string, ItemIconMapEntry>(
     Object.entries(itemIconSnapshot ?? {})
@@ -1685,6 +1698,7 @@ async function loadBuildContext(repoRoot: string): Promise<BuildContext> {
     localizedNamesByGuid,
     abilityCatalogByPrefab,
     abilityTooltipByPrefab,
+    serverDamageByPrefab,
     itemIconByPrefab,
     itemDescriptionByPrefab,
     recipeLinkByPrefab,
@@ -2084,7 +2098,12 @@ function buildNpcEntity(doc: PrefabDocument, components: Map<string, ParsedCompo
   });
 }
 
-function buildAbilityEntity(doc: PrefabDocument, components: Map<string, ParsedComponent>, buildContext: BuildContext): EntityBundle | null {
+function buildAbilityEntity(
+  doc: PrefabDocument,
+  components: Map<string, ParsedComponent>,
+  buildContext: BuildContext,
+  abilityDamageWalker: AbilityPrefabGraphWalker | undefined
+): EntityBundle | null {
   const docCategories = getDocCategories(doc);
   const isAbility = doc.prefabName.startsWith("AB_") || doc.prefabName.startsWith("Ability_") || docCategories.includes("Ability");
   if (!isAbility) {
@@ -2124,7 +2143,28 @@ function buildAbilityEntity(doc: PrefabDocument, components: Map<string, ParsedC
   const tierLabel = catalogEntry ? formatCatalogTier(catalogEntry.tier) : extractTier(doc.prefabName);
   const tooltipText = cleanDisplayText(tooltipEntry?.tooltipTextEn);
   const description = buildAbilityDescription(title, runtimeKind, tooltipText, abilityForm, doc.prefabName, target);
-  const textVariableValues = filterTextVariableValues(description, tooltipEntry?.textVariableValues);
+  const categories = uniqueStrings([
+    ...normalizedDocCategories,
+    runtimeKind,
+    abilityForm,
+    catalogEntry?.school,
+    tierLabel,
+    behaviorType && behaviorType !== "None" ? behaviorType : undefined
+  ]);
+  const initialTextVariableValues = filterTextVariableValues(description, tooltipEntry?.textVariableValues);
+  const shouldAttachRuntimeDamageEvidence = categories.includes("Player Usable") || /\{[A-Za-z0-9_]*damage[A-Za-z0-9_]*\}/i.test(description ?? "");
+  const damageEvidenceResult = abilityDamageWalker && shouldAttachRuntimeDamageEvidence
+    ? buildAbilityDamageEvidence({
+        abilityPrefab: doc.prefabName,
+        abilityCategories: categories,
+        description: description ?? "",
+        existingTextVariableValues: initialTextVariableValues,
+        walker: abilityDamageWalker,
+        damageEvidence: buildContext.serverDamageByPrefab
+      })
+    : { runtimeDamageEvidence: [], textVariableValues: initialTextVariableValues };
+  const runtimeDamageEvidence = damageEvidenceResult.runtimeDamageEvidence;
+  const textVariableValues = filterTextVariableValues(description, damageEvidenceResult.textVariableValues);
   const summary = uniqueStrings([
     runtimeKind,
     abilityForm,
@@ -2141,18 +2181,11 @@ function buildAbilityEntity(doc: PrefabDocument, components: Map<string, ParsedC
     title,
     subtitle,
     description,
-    categories: uniqueStrings([
-      ...normalizedDocCategories,
-      runtimeKind,
-      abilityForm,
-      catalogEntry?.school,
-      tierLabel,
-      behaviorType && behaviorType !== "None" ? behaviorType : undefined
-    ]),
+    categories,
     summary,
     tier: tierLabel,
     icon: catalogEntry?.icon,
-    tags: [inputType, target, ...spawnedPrefabs.map((item) => item.prefab)],
+    tags: [inputType, target, ...spawnedPrefabs.map((item) => item.prefab), ...runtimeDamageEvidence.map((item) => item.sourcePrefab)],
     textVariableValues,
     indexFields: {
       school: catalogEntry?.school,
@@ -2179,7 +2212,8 @@ function buildAbilityEntity(doc: PrefabDocument, components: Map<string, ParsedC
       tooltipTextEn: tooltipText,
       tooltipSourceKind: tooltipEntry?.sourceKind,
       tooltipSourceRef: tooltipEntry?.sourceRef,
-      spawnedPrefabs
+      spawnedPrefabs,
+      ...(runtimeDamageEvidence.length > 0 ? { runtimeDamageEvidence } : {})
     }
   });
 }
@@ -2622,6 +2656,24 @@ async function loadRealEntities(repoRoot: string): Promise<Record<Section, Entit
     componentCache.set(doc.filePath, parsed);
     return parsed;
   };
+  const prefabGraphNodes = new Map<string, AbilityDamagePrefabNode>(
+    docs.map((doc) => [
+      doc.prefabName,
+      {
+        prefabName: doc.prefabName,
+        guid: doc.guid,
+        components: getComponents(doc)
+      }
+    ])
+  );
+  const abilityDamageWalker =
+    buildContext.serverDamageByPrefab.size > 0
+      ? createAbilityPrefabGraphWalker({
+          prefabs: prefabGraphNodes,
+          maxDepth: 5,
+          maxNodes: 80
+        })
+      : undefined;
 
   const itemDocs = docs.filter(
     (doc) => doc.prefabName.startsWith("Item_") || doc.prefabName.startsWith("FakeItem_") || doc.prefabName === "LegendaryItem_Template"
@@ -2677,7 +2729,7 @@ async function loadRealEntities(repoRoot: string): Promise<Record<Section, Entit
     const npc = buildNpcEntity(doc, components, buildContext);
     if (npc) entities.npcs.push(npc);
 
-    const ability = buildAbilityEntity(doc, components, buildContext);
+    const ability = buildAbilityEntity(doc, components, buildContext, abilityDamageWalker);
     if (ability) entities.abilities.push(ability);
 
     const workstation = buildWorkstationEntity(doc, components, buildContext);

--- a/src/components/db/DbDetailView.tsx
+++ b/src/components/db/DbDetailView.tsx
@@ -6,11 +6,24 @@ import { CopyValueButton } from "../common/CopyValueButton";
 import { VariableText } from "../common/VariableText";
 import { headingId } from "../../lib/text";
 import { DbSection } from "../../config/sections";
-import { DbEntityDetail, DbRelatedEntityRef } from "../../types/db";
+import { DbEntityDetail, DbRelatedEntityRef, DbRuntimeDamageEvidence } from "../../types/db";
 import { DbBadge, DbDisplayRow, DbFieldGrid, DbIconAvatar, DbReferenceList, DbSurface } from "./DbCards";
 import { DbFieldSpec, DbRelationSpec, dbSchemas, hasDbSchema } from "./dbSchemas";
 
-const hiddenKeys = new Set(["slug", "title", "subtitle", "description", "summary", "categories", "tier", "tags", "prefabPath", "icon", "textVariableValues"]);
+const hiddenKeys = new Set([
+  "slug",
+  "title",
+  "subtitle",
+  "description",
+  "summary",
+  "categories",
+  "tier",
+  "tags",
+  "prefabPath",
+  "icon",
+  "textVariableValues",
+  "runtimeDamageEvidence"
+]);
 const copyKeyPattern = /(guid|path|prefab|route|source)/i;
 
 interface ProvenanceLink {
@@ -68,6 +81,10 @@ function formatNumber(value: number): string {
   return value.toFixed(2).replace(/\.?0+$/, "");
 }
 
+function formatRawDamagePercent(value: number): string {
+  return `${formatNumber(value * 100)}%`;
+}
+
 function formatDuration(seconds: number): string {
   if (seconds < 60) {
     return `${formatNumber(seconds)}s`;
@@ -120,6 +137,20 @@ function isRelatedEntityRef(value: unknown): value is DbRelatedEntityRef {
 
 function isRelatedEntityList(value: unknown): value is DbRelatedEntityRef[] {
   return Array.isArray(value) && value.every((item) => isRelatedEntityRef(item));
+}
+
+function isRuntimeDamageEvidence(value: unknown): value is DbRuntimeDamageEvidence {
+  return (
+    isRecord(value) &&
+    value.sourceKind === "server-damage-evidence" &&
+    typeof value.sourceRef === "string" &&
+    typeof value.sourcePrefab === "string" &&
+    typeof value.graphDepth === "number"
+  );
+}
+
+function isRuntimeDamageEvidenceList(value: unknown): value is DbRuntimeDamageEvidence[] {
+  return Array.isArray(value) && value.every(isRuntimeDamageEvidence);
 }
 
 function isDisplayRow(value: DbDisplayRow | null): value is DbDisplayRow {
@@ -338,6 +369,64 @@ function renderAbilityTooltipSurface(section: DbSection, detail: DbEntityDetail)
           </div>
         ) : null}
         {tooltipRows.length > 0 ? <DbFieldGrid rows={tooltipRows} /> : null}
+      </div>
+    </DbSurface>
+  );
+}
+
+function renderRuntimeDamageEvidenceSurface(section: DbSection, detail: DbEntityDetail) {
+  if (section !== "abilities" || !isRuntimeDamageEvidenceList(detail.runtimeDamageEvidence) || detail.runtimeDamageEvidence.length === 0) {
+    return null;
+  }
+
+  const entries = detail.runtimeDamageEvidence;
+  const visibleEntries = entries.slice(0, 12);
+  const hiddenCount = entries.length - visibleEntries.length;
+
+  return (
+    <DbSurface title="Runtime Damage Evidence" anchorId="runtime-damage-evidence" meta={`${entries.length} raw source${entries.length === 1 ? "" : "s"}`}>
+      <div className="space-y-3">
+        <div className="grid gap-3 lg:grid-cols-2">
+          {visibleEntries.map((entry) => {
+            const rawDamagePercent = typeof entry.RawDamagePercent === "number" ? formatRawDamagePercent(entry.RawDamagePercent) : undefined;
+            const rawDamageValue = typeof entry.RawDamageValue === "number" ? formatNumber(entry.RawDamageValue) : undefined;
+            const factorRowCandidates: Array<DbDisplayRow | null> = [
+              rawDamagePercent ? { key: "RawDamagePercent", label: "Raw Percent", value: rawDamagePercent } : null,
+              rawDamageValue ? { key: "RawDamageValue", label: "Raw Value", value: rawDamageValue } : null,
+              typeof entry.MainFactor === "number" ? { key: "MainFactor", label: "Main Factor", value: formatNumber(entry.MainFactor) } : null,
+              typeof entry.ResourceModifier === "number" ? { key: "ResourceModifier", label: "Resource Modifier", value: formatNumber(entry.ResourceModifier) } : null,
+              typeof entry.StaggerFactor === "number" ? { key: "StaggerFactor", label: "Stagger Factor", value: formatNumber(entry.StaggerFactor) } : null,
+              typeof entry.DamageModifierPerHit === "number" ? { key: "DamageModifierPerHit", label: "Per-Hit Modifier", value: formatNumber(entry.DamageModifierPerHit) } : null,
+              typeof entry.MultiplyMainFactorWithStacks === "boolean"
+                ? { key: "MultiplyMainFactorWithStacks", label: "Stack Multiplier", value: entry.MultiplyMainFactorWithStacks ? "Yes" : "No" }
+                : null
+            ];
+            const factorRows = factorRowCandidates.filter(isDisplayRow);
+
+            return (
+              <article key={`${entry.sourcePrefab}:${entry.sourceRef}`} className="database-list-surface rounded-[1rem] p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="font-mono text-xs text-[var(--database-accent-soft)]">{entry.sourcePrefab}</div>
+                    <div className="mt-1 text-[10px] uppercase tracking-[0.18em] text-[var(--database-dim)]">Graph depth {formatNumber(entry.graphDepth)}</div>
+                  </div>
+                  {rawDamagePercent ? <div className="shrink-0 text-sm font-semibold text-[var(--database-ink)]">{rawDamagePercent}</div> : null}
+                </div>
+
+                {factorRows.length > 0 ? <DbFieldGrid rows={factorRows} /> : null}
+
+                <div className="mt-3 flex items-start justify-between gap-3 border-t border-[var(--database-border)] pt-3">
+                  <div>
+                    <div className="text-[10px] uppercase tracking-[0.18em] text-[var(--database-dim)]">Source</div>
+                    <div className="mt-1 break-all font-mono text-[11px] text-[var(--database-accent-soft)]">{entry.sourceRef}</div>
+                  </div>
+                  <CopyValueButton value={entry.sourceRef} className="shrink-0" />
+                </div>
+              </article>
+            );
+          })}
+        </div>
+        {hiddenCount > 0 ? <p className="text-xs text-[var(--database-dim)]">{hiddenCount} additional raw damage sources are preserved in the generated detail JSON.</p> : null}
       </div>
     </DbSurface>
   );
@@ -992,6 +1081,7 @@ function buildSchemaJumpItems(
   detail: DbEntityDetail,
   playerRows: DbDisplayRow[],
   hasTooltipSurface: boolean,
+  hasRuntimeDamageEvidence: boolean,
   detailRows: DbDisplayRow[],
   usageRows: DbDisplayRow[],
   genericFieldRows: DbDisplayRow[],
@@ -1008,6 +1098,10 @@ function buildSchemaJumpItems(
 
   if (hasTooltipSurface) {
     items.push({ id: "tooltip-capture", label: "Tooltip Capture" });
+  }
+
+  if (hasRuntimeDamageEvidence) {
+    items.push({ id: "runtime-damage-evidence", label: "Damage Evidence" });
   }
 
   if (usageRows.length > 0) {
@@ -1056,6 +1150,8 @@ function renderSchemaDetail(section: DbSection, detail: DbEntityDetail) {
   const hasAbilityTooltipSurface =
     section === "abilities" &&
     (abilityTooltipRows.length > 0 || (typeof detail.tooltipTextEn === "string" && detail.tooltipTextEn.trim().length > 0));
+  const hasRuntimeDamageEvidence =
+    section === "abilities" && isRuntimeDamageEvidenceList(detail.runtimeDamageEvidence) && detail.runtimeDamageEvidence.length > 0;
   const detailRows = buildRowsFromSpecs(detail, schema.detailFields ?? []).filter((row) => row.key !== heroBodyKey);
   const usageRows = buildRowsFromSpecs(detail, schema.usageFields ?? []);
   const provenanceRows = buildRowsFromSpecs(detail, schema.provenanceFields ?? []);
@@ -1082,6 +1178,7 @@ function renderSchemaDetail(section: DbSection, detail: DbEntityDetail) {
     detail,
     playerRows,
     hasAbilityTooltipSurface,
+    hasRuntimeDamageEvidence,
     detailRows,
     usageRows,
     genericFieldRows,
@@ -1104,6 +1201,8 @@ function renderSchemaDetail(section: DbSection, detail: DbEntityDetail) {
         ) : null}
 
         {renderAbilityTooltipSurface(section, detail)}
+
+        {renderRuntimeDamageEvidenceSurface(section, detail)}
 
         {usageRows.length > 0 ? (
           <DbSurface title={schema.usageSectionTitle ?? "Usage & Links"} anchorId="usage-links">

--- a/src/lib/textVariables.ts
+++ b/src/lib/textVariables.ts
@@ -12,7 +12,7 @@ export type TextVariableSegment =
 
 const textVariablePattern = /\{[A-Za-z0-9_]+\}/g;
 
-export type TextVariableSourceKind = "localized-resource" | "bloodcraft-resource";
+export type TextVariableSourceKind = "localized-resource" | "bloodcraft-resource" | "server-damage-evidence";
 
 export interface TextVariableResolution {
   value: string;
@@ -24,7 +24,7 @@ export interface TextVariableResolution {
 
 export type TextVariableResolutionMap = Record<string, TextVariableResolution>;
 
-const textVariableSourceKinds = new Set<string>(["localized-resource", "bloodcraft-resource"]);
+const textVariableSourceKinds = new Set<string>(["localized-resource", "bloodcraft-resource", "server-damage-evidence"]);
 
 export function isTextVariableSourceKind(value: string | undefined | null): value is TextVariableSourceKind {
   return Boolean(value && textVariableSourceKinds.has(value));

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -60,6 +60,24 @@ export interface DbRelatedEntityRef {
   icon?: string;
 }
 
+export interface DbRuntimeDamageEvidence {
+  sourceKind: "server-damage-evidence";
+  sourceRef: string;
+  sourcePrefab: string;
+  sourceGuid: number | null;
+  graphDepth: number;
+  interpretationStatus?: string;
+  RawDamagePercent?: number;
+  RawDamageValue?: number;
+  MainFactor?: number;
+  ResourceModifier?: number;
+  StaggerFactor?: number;
+  DamageModifierPerHit?: number;
+  MultiplyMainFactorWithStacks?: boolean;
+  DealDamageFlags?: number;
+  MainType?: string;
+}
+
 export interface DbEntityDetail {
   slug: string;
   title: string;
@@ -100,6 +118,7 @@ export interface DbEntityDetail {
   normalizedSourceRef?: string;
   tags?: string[];
   textVariableValues?: TextVariableResolutionMap;
+  runtimeDamageEvidence?: DbRuntimeDamageEvidence[];
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
- Add a bounded AB/effect prefab graph walker for source-backed runtime damage evidence.
- Surface raw `DealDamageOnGameplayEvent` facts on ability detail pages.
- Resolve only safe singleton positive-percent damage tooltip tokens.

## Test Plan
- `npm test`
- `npm run verify`

## Notes
- Clean replacement for closed PR #132.
- `npm run verify` passes with existing enrichment-threshold warnings for NPC/blueprint/quest/buff/itemset coverage.