### PR TITLE
[codex] Trim homepage copy

### DIFF
--- a/src/config/home.ts
+++ b/src/config/home.ts
@@ -19,14 +19,13 @@ export interface HomeLandingBand {
 }
 
 export const homeHeroSummary =
-  "Generated gameplay and prefab reference data for mechanics, progression, and world inspection. For guides, community docs, Discord, and Thunderstore direction, visit the Community Wiki.";
+  "Generated gameplay and prefab reference data for mechanics, progression, and world inspection.";
 
 export const homeLandingBands: HomeLandingBand[] = [
   {
     id: "gameplay-data",
     title: "Gameplay Data",
     description: "Start with the generated records that explain combat, items, drops, and craft progression.",
-    helperText: "This is the data companion surface; the Community Wiki remains the home for authored guides and community context.",
     items: [
       {
         id: "abilities",


### PR DESCRIPTION
## Summary

- Trims the homepage hero summary so it focuses on generated gameplay and prefab reference data.
- Removes the redundant `Gameplay Data` helper sentence that repeated the Community Wiki direction already shown above.

## Why

The front-page copy had two separate Community Wiki pointers close together. Keeping the smaller dedicated wiki link makes the page read cleaner while preserving the guide/community-doc direction for users.

## Impact

This is a text-only homepage change. It should make the first viewport slightly less repetitive and leave room to gather real usage feedback before deciding whether more homepage positioning changes are needed.

## Validation

- `npm run verify`