### PR TITLE
Use tracked fixtures for DbDetailView tests

### DIFF
--- a/src/components/db/DbDetailView.test.fixtures.ts
+++ b/src/components/db/DbDetailView.test.fixtures.ts
@@ -1,0 +1,153 @@
+import { DbEntityDetail, DbRelatedEntityRef } from "../../types/db";
+
+const boneguardBoots: DbRelatedEntityRef = {
+  title: "Boneguard Boots",
+  prefab: "Item_Boots_T01_Bone",
+  guid: 172364,
+  amount: 1,
+  path: "/db/items/item-boots-t01-bone",
+  icon: "/icons/items/Item_Boots_T01_Bone.png"
+};
+
+const bone: DbRelatedEntityRef = {
+  title: "Bone",
+  prefab: "Item_Ingredient_Bone",
+  guid: 862477,
+  amount: 16,
+  path: "/db/items/item-ingredient-bone",
+  icon: "/icons/items/Item_Ingredient_Bone.png"
+};
+
+const ruggedHide: DbRelatedEntityRef = {
+  title: "Rugged Hide",
+  prefab: "Item_Ingredient_RuggedHide",
+  guid: 168531,
+  amount: 32,
+  path: "/db/items/item-ingredient-rugged-hide",
+  icon: "/icons/items/Item_Ingredient_RuggedHide.png"
+};
+
+const boneguardBootsRecipe: DbRelatedEntityRef = {
+  title: "Boneguard Boots Recipe",
+  prefab: "Recipe_Armor_Boots_T01_Bone",
+  guid: 110024,
+  path: "/db/recipes/recipe-armor-boots-t01-bone"
+};
+
+const jewelcraftingOutput: DbRelatedEntityRef = {
+  title: "Merciless Copper Ring",
+  prefab: "Item_Jewel_Ring_T02_Copper",
+  guid: 278312,
+  path: "/db/items/item-jewel-ring-t02-copper"
+};
+
+const jewelcraftingRecipe: DbRelatedEntityRef = {
+  title: "Merciless Copper Ring Recipe",
+  prefab: "Recipe_Jewel_Ring_T02_Copper",
+  guid: 278313,
+  path: "/db/recipes/recipe-jewel-ring-t02-copper"
+};
+
+const sawmillInventory: DbRelatedEntityRef = {
+  title: "Sawmill Inventory",
+  prefab: "Inventory_Sawmill",
+  guid: 99120,
+  path: "/prefabs/inventory-sawmill"
+};
+
+export const recipeDetailFixture: DbEntityDetail = {
+  slug: "recipe-armor-boots-t01-bone",
+  title: "Boneguard Boots Recipe",
+  subtitle: "Recipe_Armor_Boots_T01_Bone",
+  description: "Boneguard Boots recipe generated summary.",
+  categories: ["T01", "Armor", "Footgear", "Bloodbound"],
+  recipeGroup: "Armor",
+  recipeFamily: "Footgear",
+  craftDuration: 4,
+  outputCount: 1,
+  requirementCount: 2,
+  repairCostCount: 1,
+  crafts: "1x Boneguard Boots",
+  requires: "16x Bone, 32x Rugged Hide",
+  repairsWith: "16x Bone",
+  outputs: [boneguardBoots],
+  requirements: [bone, ruggedHide],
+  repairCosts: [bone]
+};
+
+export const itemDetailFixture: DbEntityDetail = {
+  slug: "item-boots-t01-bone",
+  title: "Boneguard Boots",
+  subtitle: "Item_Boots_T01_Bone",
+  summary: "None item, max stack 1.",
+  categories: ["Armor", "Footgear", "Equippable"],
+  itemGroup: "Armor",
+  itemFamily: "Footgear",
+  itemType: "Equippable",
+  equipmentType: "Footgear",
+  maxAmount: 1,
+  durability: 426,
+  localizedDescriptionTextEn: "Armour made from collecting the bones of the dead.",
+  relatedRecipes: [boneguardBootsRecipe],
+  repairRecipes: [boneguardBootsRecipe],
+  icon: "/icons/items/Item_Boots_T01_Bone.png"
+};
+
+export const npcDetailFixture: DbEntityDetail = {
+  slug: "char-bandit-bomber",
+  title: "Bomber",
+  subtitle: "CHAR_Bandit_Bomber",
+  description: "Bomber is an NPC unit with preserved aggro, movement, and drop context for encounter reference.",
+  categories: ["CHAR", "Servant Convertible", "Human", "Warrior Blood"],
+  prefab: "CHAR_Bandit_Bomber",
+  npcKind: "Blood Carrier",
+  npcLevel: 32,
+  npcBloodType: "Warrior",
+  npcFaction: "Bandits",
+  npcUnitCategory: "Human",
+  essenceGain: 15,
+  runSpeed: 3.5,
+  aggroRadius: 15,
+  leashDistance: 45,
+  servantPrefabs: [
+    {
+      title: "CHAR Bandit Bomber Servant",
+      prefab: "CHAR_Bandit_Bomber_Servant",
+      guid: -450600397,
+      path: "/prefabs/char-bandit-bomber-servant"
+    }
+  ],
+  essenceItemPrefabs: [
+    {
+      title: "Item Blood Essence T01",
+      prefab: "Item_BloodEssence_T01",
+      guid: 862477668,
+      path: "/prefabs/item-blood-essence-t01"
+    }
+  ]
+};
+
+export const workstationDetailFixture: DbEntityDetail = {
+  slug: "tm-crafting-station-jewelcrafting-table",
+  title: "Jewelcrafting Table",
+  subtitle: "TM_CraftingStation_JewelcraftingTable",
+  description: "Station workstation record with player-facing naming and technical prefab context.",
+  categories: ["TM", "Castle Workstation", "Station"],
+  workstationRole: "Station",
+  stationKind: "Castle Workstation",
+  matchingFloorType: "Temple",
+  bonusServantType: "None",
+  workstationRecipeCount: 126,
+  workstationOutputCount: 126,
+  portraitAssetPath: "/icons/buildables/Stunlock_Icon_Structure_JewelcraftingTable.png",
+  workstationOutputs: [jewelcraftingOutput],
+  workstationRecipes: [jewelcraftingRecipe]
+};
+
+export const workstationWithInventoryDetailFixture: DbEntityDetail = {
+  ...workstationDetailFixture,
+  slug: "tm-refinement-station-sawmill-large",
+  title: "Sawmill",
+  subtitle: "TM_RefinementStation_Sawmill_Large",
+  inventoryPrefabs: [sawmillInventory]
+};

--- a/src/components/db/DbDetailView.test.tsx
+++ b/src/components/db/DbDetailView.test.tsx
@@ -3,14 +3,16 @@ import test from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
-import itemDetail from "../../../public/data/db/items/by-slug/item-boots-t01-bone.json";
-import npcDetail from "../../../public/data/db/npcs/by-slug/char-bandit-bomber.json";
-import recipeDetail from "../../../public/data/db/recipes/by-slug/recipe-armor-boots-t01-bone.json";
-import workstationDetail from "../../../public/data/db/workstations/by-slug/tm-crafting-station-jewelcrafting-table.json";
-import workstationWithInventoryDetail from "../../../public/data/db/workstations/by-slug/tm-refinement-station-sawmill-large.json";
 import { DbSection } from "../../config/sections";
 import { DbEntityDetail } from "../../types/db";
 import { DbDetailView } from "./DbDetailView";
+import {
+  itemDetailFixture,
+  npcDetailFixture,
+  recipeDetailFixture,
+  workstationDetailFixture,
+  workstationWithInventoryDetailFixture
+} from "./DbDetailView.test.fixtures";
 
 function renderWithoutLayoutWarning(render: () => string) {
   const originalError = console.error;
@@ -41,23 +43,23 @@ function renderDetail(detail: DbEntityDetail, section: DbSection) {
 }
 
 function renderRecipeDetail() {
-  return renderDetail(recipeDetail as DbEntityDetail, "recipes");
+  return renderDetail(recipeDetailFixture, "recipes");
 }
 
 function renderItemDetail() {
-  return renderDetail(itemDetail as DbEntityDetail, "items");
+  return renderDetail(itemDetailFixture, "items");
 }
 
 function renderNpcDetail() {
-  return renderDetail(npcDetail as DbEntityDetail, "npcs");
+  return renderDetail(npcDetailFixture, "npcs");
 }
 
 function renderWorkstationDetail() {
-  return renderDetail(workstationDetail as DbEntityDetail, "workstations");
+  return renderDetail(workstationDetailFixture, "workstations");
 }
 
 function renderWorkstationWithInventoryDetail() {
-  return renderDetail(workstationWithInventoryDetail as DbEntityDetail, "workstations");
+  return renderDetail(workstationWithInventoryDetailFixture, "workstations");
 }
 
 function countMatches(value: string, pattern: RegExp): number {
@@ -184,7 +186,7 @@ test("structured workstation detail keeps summary cues while consolidating dupli
 });
 
 test("structured workstation detail does not render a portrait placeholder without a source-backed path", () => {
-  const html = renderDetail({ ...(workstationDetail as DbEntityDetail), portraitAssetPath: undefined }, "workstations");
+  const html = renderDetail({ ...workstationDetailFixture, portraitAssetPath: undefined }, "workstations");
 
   assert.doesNotMatch(html, /station portrait/);
   assert.doesNotMatch(html, /\/icons\/buildables\//);


### PR DESCRIPTION
## Summary
- replace ignored generated `public/data/db` imports in `DbDetailView.test.tsx` with tracked fixtures
- add minimal fixture data for the existing recipe, item, NPC, and workstation SSR assertions

## Verification
- `npx tsx --test src/components/db/DbDetailView.test.tsx` passed locally before creating this follow-up branch
- `npx tsc --noEmit` passed locally before creating this follow-up branch
- `npm test` passed locally before creating this follow-up branch
- `npm run verify` passed locally before creating this follow-up branch

Follow-up for PR #138 CI failure: https://github.com/mfoltz/mfoltz.github.io/pull/138#discussion_r3211681031